### PR TITLE
Use no user when the users section is missing in kubeconfig

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -130,7 +130,8 @@ class KubeConfigLoader(object):
             context_name = self._config['current-context']
         self._current_context = self._config['contexts'].get_with_name(
             context_name)
-        if self._current_context['context'].safe_get('user'):
+        if (self._current_context['context'].safe_get('user')
+                and self._config.safe_get('users')):
             self._user = self._config['users'].get_with_name(
                 self._current_context['context']['user'])['user']
         else:

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -615,6 +615,17 @@ class TestKubeConfigLoader(BaseTestCase):
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
                          client.config.api_key['authorization'])
 
+    def test_no_users_section(self):
+        expected = FakeConfig(host=TEST_HOST)
+        actual = FakeConfig()
+        test_kube_config = self.TEST_KUBE_CONFIG.copy()
+        del test_kube_config['users']
+        KubeConfigLoader(
+            config_dict=test_kube_config,
+            active_context="gcp",
+            client_configuration=actual).load_and_set()
+        self.assertEqual(expected, actual)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes kubernetes-incubator/client-python#236