### PR TITLE
Add http_proxy configuration with unittest

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -82,13 +82,14 @@ class ConfigurationObject(object):
         # check host name
         # Set this to True/False to enable/disable SSL hostname verification.
         self.assert_hostname = None
-
         # urllib3 connection pool's maximum number of connections saved
         # per pool. Increasing this is useful for cases when you are
         # making a lot of possibly parallel requests to the same host,
         # which is often the case here.
         # When set to `None`, will default to whatever urllib3 uses
         self.connection_pool_maxsize = None
+        # http proxy setting
+        self.http_proxy_url = None
 
         # WebSocket subprotocol to use for exec and portforward.
         self.ws_streaming_protocol = "v4.channel.k8s.io"

--- a/rest.py
+++ b/rest.py
@@ -106,9 +106,14 @@ class RESTClientObject(object):
             kwargs['assert_hostname'] = config.assert_hostname
 
         # https pool manager
-        self.pool_manager = urllib3.PoolManager(
-            **kwargs
-        )
+        if config.http_proxy_url is not None:
+            self.pool_manager = urllib3.proxy_from_url(
+                config.http_proxy_url, **kwargs
+            )
+        else:
+            self.pool_manager = urllib3.PoolManager(
+	        **kwargs
+            )
 
     def request(self, method, url, query_params=None, headers=None,
                 body=None, post_params=None, _preload_content=True,

--- a/rest_test.py
+++ b/rest_test.py
@@ -16,7 +16,7 @@ import urllib3
 
 from mock import patch
 
-from kubernetes.client import Configuration
+from kubernetes.client import ConfigurationObject
 from kubernetes.client.rest import RESTClientObject
 
 
@@ -25,12 +25,12 @@ class RestTest(unittest.TestCase):
     def test_poolmanager(self):
         'Test that a poolmanager is created for rest client'
         with patch.object(urllib3, 'PoolManager') as pool:
-            RESTClientObject(config=Configuration())
+            RESTClientObject(config=ConfigurationObject())
             pool.assert_called_once()
 
     def test_proxy(self):
         'Test that proxy is created when the config especifies it'
-        config = Configuration()
+        config = ConfigurationObject()
         config.http_proxy_url = 'http://proxy.example.com'
 
         with patch.object(urllib3, 'proxy_from_url') as proxy:

--- a/rest_test.py
+++ b/rest_test.py
@@ -1,0 +1,42 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+import urllib3
+
+from mock import patch
+
+from kubernetes.client import Configuration
+from kubernetes.client.rest import RESTClientObject
+
+
+class RestTest(unittest.TestCase):
+
+    def test_poolmanager(self):
+        'Test that a poolmanager is created for rest client'
+        with patch.object(urllib3, 'PoolManager') as pool:
+            RESTClientObject(config=Configuration())
+            pool.assert_called_once()
+
+    def test_proxy(self):
+        'Test that proxy is created when the config especifies it'
+        config = Configuration()
+        config.http_proxy_url = 'http://proxy.example.com'
+
+        with patch.object(urllib3, 'proxy_from_url') as proxy:
+            RESTClientObject(config=config)
+            proxy.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR extends #8 by adding some unit test for the PoolManager and the proxy manager. 