### PR TITLE
Use oauth2 from google-auth

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -19,7 +19,7 @@ import tempfile
 
 import urllib3
 import yaml
-from oauth2client.client import GoogleCredentials
+from google.oauth2.credentials import Credentials
 
 from kubernetes.client import ApiClient, ConfigurationObject, configuration
 


### PR DESCRIPTION
oauth2client is deprecated [1], use google-auth.

[1] https://github.com/google/oauth2client/releases (see Note)

Related-Issue: https://github.com/kubernetes-incubator/client-python/issues/275

Signed-off-by: Spyros Trigazis <spyridon.trigazis@cern.ch>