### PR TITLE
Add ws_streaming_protocol and use v4 by default

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -90,6 +90,9 @@ class ConfigurationObject(object):
         # When set to `None`, will default to whatever urllib3 uses
         self.connection_pool_maxsize = None
 
+        # WebSocket subprotocol to use for exec and portforward.
+        self.ws_streaming_protocol = "v4.channel.k8s.io"
+
     @property
     def logger_file(self):
         """


### PR DESCRIPTION
To be sent in the Sec-WebSocket-Protocol http header by the ws_client.

ref: https://github.com/kubernetes-incubator/client-python/issues/297