### PR TITLE
Fixing get Google default credentials method

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -122,13 +122,16 @@ class KubeConfigLoader(object):
         self.set_active_context(active_context)
         self._config_base_path = config_base_path
 
-        if get_google_credentials:
-            self._get_google_credentials = get_google_credentials
-        else:
+        def _refresh_credentials():
             credentials, project_id = google.auth.default()
             request = google.auth.transport.requests.Request()
             credentials.refresh(request)
-            self._get_google_credentials = lambda: (credentials.token)
+            return credentials.token
+
+        if get_google_credentials:
+            self._get_google_credentials = get_google_credentials
+        else:
+            self._get_google_credentials = _refresh_credentials
         self._client_configuration = client_configuration
 
     def set_active_context(self, context_name=None):

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -122,16 +122,13 @@ class KubeConfigLoader(object):
         self.set_active_context(active_context)
         self._config_base_path = config_base_path
 
-        def _refresh_credentials():
-            credentials, project_id = google.auth.default()
-            request = google.auth.transport.requests.Request()
-            credentials.refresh(request)
-            return credentials.token
-
         if get_google_credentials:
             self._get_google_credentials = get_google_credentials
         else:
-            self._get_google_credentials = _refresh_credentials
+            credentials, project_id = google.auth.default()
+            request = google.auth.transport.requests.Request()
+            credentials.refresh(request)
+            self._get_google_credentials = lambda: (credentials.token)
         self._client_configuration = client_configuration
 
     def set_active_context(self, context_name=None):


### PR DESCRIPTION
This should fix the following error:
```
Traceback (most recent call last):
  File "watch-namespace.py", line 4, in <module>
    config.load_kube_config()
  File "egg/kubernetes/config/kube_config.py", line 318, in load_kube_config
  File "egg/kubernetes/config/kube_config.py", line 221, in load_and_set
  File "egg/kubernetes/config/kube_config.py", line 160, in _load_authentication
  File "egg/kubernetes/config/kube_config.py", line 176, in _load_gcp_token
  File "egg/kubernetes/config/kube_config.py", line 124, in <lambda>
NameError: global name 'GoogleCredentials' is not defined
```