### PR TITLE
Check if the cached temp conf file still exists before using it.

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -49,7 +49,7 @@ def _create_temp_file_with_content(content):
     # Because we may change context several times, try to remember files we
     # created and reuse them at a small memory cost.
     content_key = str(content)
-    if content_key in _temp_files:
+    if content_key in _temp_files and os.path.isfile(_temp_files[content_key]):
         return _temp_files[content_key]
     _, name = tempfile.mkstemp()
     _temp_files[content_key] = name


### PR DESCRIPTION
On some systems older unused temp files get cleaned up regularly. So,
we cannot rely on the availability of the temp_files in long running
processes.