### PR TITLE
Fix issue when refreshing service account token

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -129,7 +129,9 @@ class KubeConfigLoader(object):
         self._config_persister = config_persister
 
         def _refresh_credentials():
-            credentials, project_id = google.auth.default()
+            credentials, project_id = google.auth.default(
+                scopes=['https://www.googleapis.com/auth/cloud-platform']
+            )
             request = google.auth.transport.requests.Request()
             credentials.refresh(request)
             return credentials


### PR DESCRIPTION
@mbohlool  I believe this will fix the below issues:
https://github.com/kubernetes-incubator/client-python/issues/339
https://github.com/kubernetes-incubator/client-python/issues/386

I was able to reproduce this issue by either setting GOOGLE_APPLICATION_CREDENTIALS to a service account json key file or by setting the gcloud default application login to a service account. 

Unlike user accounts, it seems that service accounts require that we set the scope.