### PR TITLE
fixing flipped sign in expiry time padding

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -63,7 +63,7 @@ def _create_temp_file_with_content(content):
 
 
 def _is_expired(expiry):
-    return ((parse_rfc3339(expiry) + EXPIRY_SKEW_PREVENTION_DELAY) <=
+    return ((parse_rfc3339(expiry) - EXPIRY_SKEW_PREVENTION_DELAY) <=
             datetime.datetime.utcnow().replace(tzinfo=UTC))
 
 


### PR DESCRIPTION
We ran into a bug where any job that runs long enough for the API token to expire will fail with a `401 Unauthorized ApiException`. We found that this was due to a flipped sign in the padding added to the expiry. I've updated the `_is_expired` method to return `True` if the token expires _in 5 minutes_, as opposed to the current logic which returns `True` if the token expired _5 minutes ago_. I've also added an extra assertion to ensure that the `_load_gcp_token` method actually updates the expiry timestamp.

Please let me know if you have any questions or comments!