### PR TITLE
Watch properly decode resourceVersion from custom object response

### DIFF
--- a/watch/watch.py
+++ b/watch/watch.py
@@ -84,6 +84,12 @@ class Watch(object):
             js['object'] = self._api_client.deserialize(obj, return_type)
             if hasattr(js['object'], 'metadata'):
                 self.resource_version = js['object'].metadata.resource_version
+            # For custom objects that we don't have model defined, json
+            # deserialization results in dictionary
+            elif (isinstance(js['object'], dict) and 'metadata' in js['object']
+                  and 'resourceVersion' in js['object']['metadata']):
+                self.resource_version = js['object']['metadata'][
+                    'resourceVersion']
         return js
 
     def stream(self, func, *args, **kwargs):


### PR DESCRIPTION
fixes https://github.com/kubernetes-client/python/issues/503

Watch deserializes a CR json response into a dictionary instead of an object of a class, because we don't have model defined for CR, and hasattr() doesn't work for dict. As a result watch failed to update resource_version from last response. This PR tries getting resource version if the response is deserialized into a dictionary. 