### PR TITLE
The websockets client should not assume everything is UTF-8 encoded on Python 3

### DIFF
--- a/stream/stream.py
+++ b/stream/stream.py
@@ -26,9 +26,15 @@ def stream(func, *args, **kwargs):
 
         return ws_client.websocket_call(config, *args, **kwargs)
 
+    def _intercept_deserialize_call(response, response_type):
+        return response.data
+
     prev_request = func.__self__.api_client.request
+    prev_deserialize = func.__self__.api_client.deserialize
     try:
         func.__self__.api_client.request = _intercept_request_call
+        func.__self__.api_client.deserialize = _intercept_deserialize_call
         return func(*args, **kwargs)
     finally:
         func.__self__.api_client.request = prev_request
+        func.__self__.api_client.deserialize = prev_deserialize

--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -41,7 +41,7 @@ class WSClient:
         header = []
         self._connected = False
         self._channels = {}
-        self._all = ""
+        self._all = b""
 
         # We just need to pass the Authorization, ignore all the other
         # http headers we get from the generated code
@@ -147,7 +147,7 @@ class WSClient:
         channels mapped for each input.
         """
         out = self._all
-        self._all = ""
+        self._all = b""
         self._channels = {}
         return out
 
@@ -175,10 +175,13 @@ class WSClient:
                 return
             elif op_code == ABNF.OPCODE_BINARY or op_code == ABNF.OPCODE_TEXT:
                 data = frame.data
-                if six.PY3:
-                    data = data.decode("utf-8")
                 if len(data) > 1:
-                    channel = ord(data[0])
+                    if six.PY3:
+                        # On Python 3 indexing a byte string already
+                        # gives an integer.
+                        channel = data[0]
+                    else:
+                        channel = ord(data[0])
                     data = data[1:]
                     if data:
                         if channel in [STDOUT_CHANNEL, STDERR_CHANNEL]:
@@ -250,6 +253,6 @@ def websocket_call(configuration, *args, **kwargs):
         if not _preload_content:
             return client
         client.run_forever(timeout=_request_timeout)
-        return WSResponse('%s' % ''.join(client.read_all()))
+        return WSResponse(b'%s' % client.read_all())
     except (Exception, KeyboardInterrupt, SystemExit) as e:
         raise ApiException(status=0, reason=str(e))


### PR DESCRIPTION
Currently, the Kubernetes websockets client assumes that everything that it receives is encoded in UTF-8.  If you try to return binary data or data using another encoding from a command run inside a container using `connect_get_namespaced_pod_exec`, it will usually raise an exception, though it might also sometimes return mangled output.  This pull request makes it so that `exec`ed commands that return binary will be handled correctly on Python 3.  It also changes the string type of the returned STDOUT and STDERR channels to bytes.  This is consistent with both the websocket-client library and the stdlib subprocess module, both of which return bytes on Python 3.  Clients using this library can then do their own decoding, since they presumably know which encoding they expect to receive from the application they're `exec`ing.