### PR TITLE
Fix defaults not being honored by new_client_from_config

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -514,7 +514,7 @@ def new_client_from_config(
     """Loads configuration the same as load_kube_config but returns an ApiClient
     to be used with any API object. This will allow the caller to concurrently
     talk with multiple clusters."""
-    client_config = type.__call__(Configuration)
+    client_config = Configuration()
     load_kube_config(config_file=config_file, context=context,
                      client_configuration=client_config,
                      persist_config=persist_config)


### PR DESCRIPTION
Fixes https://github.com/kubernetes-client/python/issues/597

[This change](https://github.com/kubernetes-client/python-base/commit/b7a9f4a07eb39c41e7f813147a419ed0bfecbbd9#diff-a6c16d793c23d6a28f9255727fcd3373L371) seems to have broken defaults being honored by `new_client_from_config`. This switches it to allow the default values to be used.