### PR TITLE
Remove link to kubernetes-client/community

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is the utility part of the [python client](https://github.com/kubernetes-client/python). It has been added to the main
 repo using git submodules. This structure allow other developers to create
 their own kubernetes client and still use standard kubernetes python utilities.
-For more information refer to [clients-library-structure](https://github.com/kubernetes-client/community/blob/master/design-docs/clients-library-structure.md).
+For more information refer to [clients-library-structure](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/csi-client-structure-proposal.md).
 
 ## Contributing
 


### PR DESCRIPTION
Point directly to the file that the kubernetes/community link was
pointing to

ref: https://github.com/kubernetes-client/community/issues/6