### PR TITLE
Replace base64.decodestring for base64.standard_b64decode

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -105,7 +105,7 @@ class FileOrData(object):
                 else:
                     content = self._data
                 self._file = _create_temp_file_with_content(
-                    base64.decodestring(content))
+                    base64.standard_b64decode(content))
             else:
                 self._file = _create_temp_file_with_content(self._data)
         if self._file and not os.path.isfile(self._file):
@@ -120,7 +120,7 @@ class FileOrData(object):
             with open(self._file) as f:
                 if self._base64_file_content:
                     self._data = bytes.decode(
-                        base64.encodestring(str.encode(f.read())))
+                        base64.standard_b64encode(str.encode(f.read())))
                 else:
                     self._data = f.read()
         return self._data

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -40,7 +40,7 @@ NON_EXISTING_FILE = "zz_non_existing_file_472398324"
 
 
 def _base64(string):
-    return base64.encodestring(string.encode()).decode()
+    return base64.standard_b64encode(string.encode()).decode()
 
 
 def _format_expiry_datetime(dt):


### PR DESCRIPTION
Fix deprecation warning from kube_config.py ([Issue #60](https://github.com/kubernetes-client/python-base/issues/60))