### PR TITLE
ExecProvider errors when parsing null values

### DIFF
--- a/config/exec_provider.py
+++ b/config/exec_provider.py
@@ -32,16 +32,21 @@ class ExecProvider(object):
     """
 
     def __init__(self, exec_config):
+        """
+        exec_config must be of type ConfigNode because we depend on
+        safe_get(self, key) to correctly handle optional exec provider
+        config parameters.
+        """
         for key in ['command', 'apiVersion']:
             if key not in exec_config:
                 raise ConfigException(
                     'exec: malformed request. missing key \'%s\'' % key)
         self.api_version = exec_config['apiVersion']
         self.args = [exec_config['command']]
-        if 'args' in exec_config:
+        if exec_config.safe_get('args'):
             self.args.extend(exec_config['args'])
         self.env = os.environ.copy()
-        if 'env' in exec_config:
+        if exec_config.safe_get('env'):
             additional_vars = {}
             for item in exec_config['env']:
                 name = item['name']

--- a/config/exec_provider_test.py
+++ b/config/exec_provider_test.py
@@ -19,15 +19,18 @@ import mock
 
 from .config_exception import ConfigException
 from .exec_provider import ExecProvider
+from .kube_config import ConfigNode
 
 
 class ExecProviderTest(unittest.TestCase):
 
     def setUp(self):
-        self.input_ok = {
-            'command': 'aws-iam-authenticator token -i dummy',
-            'apiVersion': 'client.authentication.k8s.io/v1beta1'
-        }
+        self.input_ok = ConfigNode('test', {
+            'command': 'aws-iam-authenticator',
+            'args': ['token', '-i', 'dummy'],
+            'apiVersion': 'client.authentication.k8s.io/v1beta1',
+            'env': None
+        })
         self.output_ok = """
         {
             "apiVersion": "client.authentication.k8s.io/v1beta1",
@@ -39,7 +42,9 @@ class ExecProviderTest(unittest.TestCase):
         """
 
     def test_missing_input_keys(self):
-        exec_configs = [{}, {'command': ''}, {'apiVersion': ''}]
+        exec_configs = [ConfigNode('test1', {}),
+                        ConfigNode('test2', {'command': ''}),
+                        ConfigNode('test3', {'apiVersion': ''})]
         for exec_config in exec_configs:
             with self.assertRaises(ConfigException) as context:
                 ExecProvider(exec_config)


### PR DESCRIPTION
When executing a command like kubectl config use-context <ctx> kubectl rewrite the the kubeconfig file and adds null to optional parameters. For example a a config with 
```
users:
- name: Name1
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1alpha1
      command: heptio-authenticator-aws
```

is rewritten as:

```
users:
- name: Name1
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1alpha1
      args: null
      command: heptio-authenticator-aws
      env: null
```

When the ExecParser reads this it returns the error: 
```
ERROR: Invalid kube-config file. Expected key args in kube-config/users[name=Name1]/user/exec
```

This PR adds a test case and a fix for this issue.