### PR TITLE
Pep8 has been renamed to pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
      - python: 2.7
        env: TOXENV=py27-functional
      - python: 2.7
-       env: TOXENV=update-pep8
+       env: TOXENV=update-pycodestyle
      - python: 2.7
        env: TOXENV=docs
      - python: 2.7


### PR DESCRIPTION
Fixes kubernetes-client/python#666, 
co-PR with kubernetes-client/python#667.