### PR TITLE
Travis CI for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
        env: TOXENV=py36
      - python: 3.6
        env: TOXENV=py36-functional
+     - python: 3.7
+       env: TOXENV=py37
+     - python: 3.7
+       env: TOXENV=py37-functional
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*


### PR DESCRIPTION
See kubernetes-client/python#685.
Since we are already at Ubuntu 16.04, we can use Py37 in the TOXENV now.