### PR TITLE
[WIP] Remove absolute dependence of adal

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -21,7 +21,11 @@ import os
 import tempfile
 import time
 
-import adal
+try:
+    import adal
+except ImportError:
+    pass
+
 import google.auth
 import google.auth.transport.requests
 import oauthlib.oauth2
@@ -202,7 +206,13 @@ class KubeConfigLoader(object):
         if provider['name'] == 'gcp':
             return self._load_gcp_token(provider)
         if provider['name'] == 'azure':
-            return self._load_azure_token(provider)
+            try:
+                if 'adal' not in globals():
+                    raise ImportError("Package adal is not installed. Please install this package using pip install kubernetes[adal] or install adal separately.") 
+                else:
+                    return self._load_azure_token(provider)
+            except ImportError as e:
+                logging.error(str(e))
         if provider['name'] == 'oidc':
             return self._load_oid_token(provider)
 


### PR DESCRIPTION
Fixes kubernetes-client/python#668
Fixes kubernetes-client/python#645
Will need to be updated concurrently with a PR from the main repo.
Task list:
[x] Use try / except to handle adal import
[ ] modify setup file to add the adal option [main repo]
[ ] add adal option to the install section of documentation [main repo]
[ ] change the main test interface to install k8s with adal
[ ] add a test env and a minimal test that does not include adal