### PR TITLE
Add email scope to GCP provided credential refresh

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -141,9 +141,10 @@ class KubeConfigLoader(object):
         self._config_persister = config_persister
 
         def _refresh_credentials():
-            credentials, project_id = google.auth.default(
-                scopes=['https://www.googleapis.com/auth/cloud-platform']
-            )
+            credentials, project_id = google.auth.default(scopes=[
+                'https://www.googleapis.com/auth/cloud-platform',
+                'https://www.googleapis.com/auth/userinfo.email'
+            ])
             request = google.auth.transport.requests.Request()
             credentials.refresh(request)
             return credentials


### PR DESCRIPTION
This would fix the issue described in: https://github.com/kubernetes-client/python-base/issues/54

This is similar to the PR to [fix the issue with refreshing the service account token](https://github.com/kubernetes-client/python-base/pull/40), except this is specifically targeted at addressing service account tokens that are authenticated using RBAC. 

The issue is essentially that if the service account that is making a request to the Kubernetes API server and the request is authenticated using RBAC, then the access token will be invalid because it isn't signed by an email. By passing the `"https://www.googleapis.com/auth/userinfo.email"` when creating the credentials it will generate an access token that can be authenticated using RBAC.