### PR TITLE
Use yaml.safe_load and yaml.safe_dump

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -493,7 +493,7 @@ class ConfigNode(object):
 def _get_kube_config_loader_for_yaml_file(filename, **kwargs):
     with open(filename) as f:
         return KubeConfigLoader(
-            config_dict=yaml.load(f),
+            config_dict=yaml.safe_load(f),
             config_base_path=os.path.abspath(os.path.dirname(filename)),
             **kwargs)
 

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -896,14 +896,16 @@ class TestKubeConfigLoader(BaseTestCase):
     def test_load_kube_config(self):
         expected = FakeConfig(host=TEST_HOST,
                               token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64)
-        config_file = self._create_temp_file(yaml.safe_dump(self.TEST_KUBE_CONFIG))
+        config_file = self._create_temp_file(
+            yaml.safe_dump(self.TEST_KUBE_CONFIG))
         actual = FakeConfig()
         load_kube_config(config_file=config_file, context="simple_token",
                          client_configuration=actual)
         self.assertEqual(expected, actual)
 
     def test_list_kube_config_contexts(self):
-        config_file = self._create_temp_file(yaml.safe_dump(self.TEST_KUBE_CONFIG))
+        config_file = self._create_temp_file(
+            yaml.safe_dump(self.TEST_KUBE_CONFIG))
         contexts, active_context = list_kube_config_contexts(
             config_file=config_file)
         self.assertDictEqual(self.TEST_KUBE_CONFIG['contexts'][0],
@@ -916,7 +918,8 @@ class TestKubeConfigLoader(BaseTestCase):
                                   contexts)
 
     def test_new_client_from_config(self):
-        config_file = self._create_temp_file(yaml.safe_dump(self.TEST_KUBE_CONFIG))
+        config_file = self._create_temp_file(
+            yaml.safe_dump(self.TEST_KUBE_CONFIG))
         client = new_client_from_config(
             config_file=config_file, context="simple_token")
         self.assertEqual(TEST_HOST, client.configuration.host)

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -896,14 +896,14 @@ class TestKubeConfigLoader(BaseTestCase):
     def test_load_kube_config(self):
         expected = FakeConfig(host=TEST_HOST,
                               token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64)
-        config_file = self._create_temp_file(yaml.dump(self.TEST_KUBE_CONFIG))
+        config_file = self._create_temp_file(yaml.safe_dump(self.TEST_KUBE_CONFIG))
         actual = FakeConfig()
         load_kube_config(config_file=config_file, context="simple_token",
                          client_configuration=actual)
         self.assertEqual(expected, actual)
 
     def test_list_kube_config_contexts(self):
-        config_file = self._create_temp_file(yaml.dump(self.TEST_KUBE_CONFIG))
+        config_file = self._create_temp_file(yaml.safe_dump(self.TEST_KUBE_CONFIG))
         contexts, active_context = list_kube_config_contexts(
             config_file=config_file)
         self.assertDictEqual(self.TEST_KUBE_CONFIG['contexts'][0],
@@ -916,7 +916,7 @@ class TestKubeConfigLoader(BaseTestCase):
                                   contexts)
 
     def test_new_client_from_config(self):
-        config_file = self._create_temp_file(yaml.dump(self.TEST_KUBE_CONFIG))
+        config_file = self._create_temp_file(yaml.safe_dump(self.TEST_KUBE_CONFIG))
         client = new_client_from_config(
             config_file=config_file, context="simple_token")
         self.assertEqual(TEST_HOST, client.configuration.host)


### PR DESCRIPTION
When loading a `kubeconfig` file, the library uses the unsafe `yaml.load` method, which is vulnerable to arbitrary code execution, as described in https://nvd.nist.gov/vuln/detail/CVE-2017-18342

This PR makes sure we use the `safe_load` method. For consistency, I also change test to use the `safe_dump` method, although there is probably no risk there.

The use case for the unsafe `load` is to load data in arbitrary python classes, but in this case we unmarshal the file in a classic dict. `safe_load` has what we need for this use case.