### PR TITLE
Bugfix Azure AD auth config field 'expired-on': checking an int against time.struct_time

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -218,7 +218,10 @@ class KubeConfigLoader(object):
         if 'access-token' not in provider['config']:
             return
         if 'expires-on' in provider['config']:
-            if int(provider['config']['expires-on']) < time.gmtime():
+            expires_on_ts = int(provider['config']['expires-on'])
+            expires_on = time.gmtime(expires_on_ts)
+            now = time.gmtime()
+            if expires_on < now:
                 self._refresh_azure_token(provider['config'])
         self.token = 'Bearer %s' % provider['config']['access-token']
         return self.token


### PR DESCRIPTION
Compare two time.struct_time objects instead of an int and a
time.struct_time, which will throw a TypeError exception.

This fixes https://github.com/kubernetes-client/python-base/issues/84

This pull request is to https://github.com/kubernetes-client/python-base/pull/85 but this is an effort to revive the fix.

