### PR TITLE
Don't fail if tmp files have been deleted

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -63,7 +63,7 @@ def _create_temp_file_with_content(content):
     # Because we may change context several times, try to remember files we
     # created and reuse them at a small memory cost.
     content_key = str(content)
-    if content_key in _temp_files and os.file.isfile(_temp_files[content_key]):
+    if content_key in _temp_files and os.path.isfile(_temp_files[content_key]):
         return _temp_files[content_key]
     _, name = tempfile.mkstemp()
     _temp_files[content_key] = name

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -63,7 +63,7 @@ def _create_temp_file_with_content(content):
     # Because we may change context several times, try to remember files we
     # created and reuse them at a small memory cost.
     content_key = str(content)
-    if content_key in _temp_files:
+    if content_key in _temp_files and os.file.isfile(_temp_files[content_key]):
         return _temp_files[content_key]
     _, name = tempfile.mkstemp()
     _temp_files[content_key] = name


### PR DESCRIPTION
I had a case where files in `/tmp` were deleted I get the exception on line 118: `File does not exists: /tmp/xxxxx`. If we are going to catch it, we may as well recover from it. Especially since the file is just a cache.