### PR TITLE
Strip trailing slashes from `idp-issuer-url` to avoid 404 on refreshing token

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -332,7 +332,7 @@ class KubeConfigLoader(object):
         response = client.request(
             method="GET",
             url="%s/.well-known/openid-configuration"
-            % provider['config']['idp-issuer-url']
+            % provider['config']['idp-issuer-url'].rstrip('/')
         )
 
         if response.status != 200:


### PR DESCRIPTION
My `idp-issuer-url` ends with a trailing slash for some reason, and `KubeConfigLoader._refresh_oidc` concatenates it with `/.well-known/openid-configuration` to generate a URL that 404s.

I've just stripped the trailing slash to fix this.