### PR TITLE
Support multiple expires-on field formats

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -227,8 +227,12 @@ class KubeConfigLoader(object):
         if 'access-token' not in provider['config']:
             return
         if 'expires-on' in provider['config']:
-            if int(provider['config']['expires-on']) < time.gmtime():
-                self._refresh_azure_token(provider['config'])
+            try:
+                 if time.gmtime(int(provider['config']['expires-on'])) < time.gmtime():
+                    self._refresh_azure_token(provider['config'])
+            except ValueError:  # sometimes expires-on is not an int, but a datestring
+                if time.strptime(provider['config']['expires-on'], '%Y-%m-%d %H:%M:%S.%f') < time.gmtime():
+                    self._refresh_azure_token(provider['config'])
         self.token = 'Bearer %s' % provider['config']['access-token']
         return self.token
 

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -228,10 +228,12 @@ class KubeConfigLoader(object):
             return
         if 'expires-on' in provider['config']:
             try:
-                 if time.gmtime(int(provider['config']['expires-on'])) < time.gmtime():
+                if time.gmtime(int(provider['config']['expires-on'])) < time.gmtime():
                     self._refresh_azure_token(provider['config'])
             except ValueError:  # sometimes expires-on is not an int, but a datestring
-                if time.strptime(provider['config']['expires-on'], '%Y-%m-%d %H:%M:%S.%f') < time.gmtime():
+                parsed_time = time.strptime(
+                    provider['config']['expires-on'], '%Y-%m-%d %H:%M:%S.%f')
+                if parsed_time < time.gmtime():
                     self._refresh_azure_token(provider['config'])
         self.token = 'Bearer %s' % provider['config']['access-token']
         return self.token

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1117,7 +1117,8 @@ class TestKubeConfigMerger(BaseTestCase):
             {'context': {'cluster': 'ssl', 'user': 'ssl'}, 'name': 'ssl'},
             {'context': {'cluster': 'default', 'user': 'simple_token'},
              'name': 'simple_token'},
-            {'context': {'cluster': 'default', 'user': 'expired_oidc'}, 'name': 'expired_oidc'}]
+            {'context': {'cluster': 'default', 'user': 'expired_oidc'},
+             'name': 'expired_oidc'}]
 
         contexts, active_context = list_kube_config_contexts(
             config_file=kubeconfigs)

--- a/watch/watch_test.py
+++ b/watch/watch_test.py
@@ -78,7 +78,7 @@ class WatchTests(unittest.TestCase):
 
         fake_api = Mock()
         fake_api.read_namespaced_pod_log = Mock(return_value=fake_resp)
-        fake_api.read_namespaced_pod_log.__doc__ = ':param bool follow:\n:return: str'
+        fake_api.read_namespaced_pod_log.__doc__ = ':param bool follow:\n:return: str'  # noqa: E501
 
         w = Watch()
         count = 1


### PR DESCRIPTION
`expires-on` field in config can be an int or a time-string.

Existing code only supports an int, but some tools, such as aks-engine AAD integration for Kubernetes, write a time into this field as a string. Here the code is updated to support either int or `'%Y-%m-%d %H:%M:%S.%f'` in this field