### PR TITLE
Grow the `resource_version` monotonically when watching

### DIFF
--- a/watch/watch_test.py
+++ b/watch/watch_test.py
@@ -152,7 +152,7 @@ class WatchTests(unittest.TestCase):
             # opaque value we cannot interpret it and order it so rely
             # on k8s returning the events completely and in order
             calls.append(call(_preload_content=False, watch=True,
-                              resource_version="3"))
+                              resource_version="5"))
 
         for c, e in enumerate(w.stream(fake_api.get_namespaces,
                                        resource_version="5")):


### PR DESCRIPTION
See https://github.com/kubernetes-client/python/issues/819 for the explanation of the problem, dilemma, and examples.

With this proposal, the remembered `resource_version` grows monotonically, i.e. never decreasing. 

Specifically, after the `list...()` operation is finished, it will remember the maximum of all the resource_versions of all currently existing objects. In case of disconnection and reconnection, it will continue from the last seen state of **all** objects — as expected.
