### PR TITLE
Ensure no base64 incorrect padding errors occur in PY3

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -282,9 +282,11 @@ class KubeConfigLoader(object):
         if len(parts) != 3:  # Not a valid JWT
             return None
 
+        # Adding == to ensure sufficient padding. Extra padding is ignored
+        # by Python
         if PY3:
             jwt_attributes = json.loads(
-                base64.b64decode(parts[1]).decode('utf-8')
+                base64.b64decode(parts[1] + "==").decode('utf-8')
             )
         else:
             jwt_attributes = json.loads(
@@ -311,9 +313,11 @@ class KubeConfigLoader(object):
         if 'idp-certificate-authority-data' in provider['config']:
             ca_cert = tempfile.NamedTemporaryFile(delete=True)
 
+            # Adding == to ensure sufficient padding. Extra padding is ignored
+            # by Python
             if PY3:
                 cert = base64.b64decode(
-                    provider['config']['idp-certificate-authority-data']
+                    provider['config']['idp-certificate-authority-data'] + "=="
                 ).decode('utf-8')
             else:
                 cert = base64.b64decode(


### PR DESCRIPTION
Using a Kubernetes oid token configuration with Python 3, I encountered incorrect padding errors when the library attempted to decode the base64 string. Looking into the code base, I noticed that == is added to avoid this error in Python 2, but is mysteriously omitted from the Python 3 call.

I'm not sure why this is, especially since Python 3 has the exact same behaviour regarding insufficient padding as Python 2. Since the trick with adding == still works in Python 3, I have simply copied this from the Python 2 implementation and added a comment why this magic constant works.