### PR TITLE
Update _load_azure_token

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -227,8 +227,12 @@ class KubeConfigLoader(object):
         if 'access-token' not in provider['config']:
             return
         if 'expires-on' in provider['config']:
-            if int(provider['config']['expires-on']) < time.gmtime():
-                self._refresh_azure_token(provider['config'])
+            try:
+                 if time.gmtime(int(provider['config']['expires-on'])) < time.gmtime():
+                    self._refresh_azure_token(provider['config'])
+            except ValueError:
+                if time.strptime(provider['config']['expires-on'], '%Y-%m-%d %H:%M:%S.%f') < time.gmtime():
+                    self._refresh_azure_token(provider['config'])
         self.token = 'Bearer %s' % provider['config']['access-token']
         return self.token
 


### PR DESCRIPTION
_load_azure_token would fail if the "expires-on" field was not comprised of digits. The field isn't guaranteed to be digits, so this updates the code to also accept the date format `%Y-%m-%d %H:%M:%S.%f

FIx for #84 