### PR TITLE
Fix issue 84: Update _load_azure_token to hande str and int

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -226,7 +226,8 @@ class KubeConfigLoader(object):
         if expires_on.isdigit():
             return int(expires_on) < time.time()
         else:
-            return time.strptime(expires_on, '%Y-%m-%d %H:%M:%S.%f') < time.gmtime()
+            exp_time = time.strptime(expires_on, '%Y-%m-%d %H:%M:%S.%f')
+            return exp_time < time.gmtime()
 
     def _load_azure_token(self, provider):
         if 'config' not in provider:

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -221,13 +221,20 @@ class KubeConfigLoader(object):
         if provider['name'] == 'oidc':
             return self._load_oid_token(provider)
 
+    def _azure_is_expired(self, provider):
+        expires_on = provider['config']['expires-on']
+        if expires_on.isdigit():
+            return int(expires_on) < time.time()
+        else:
+            return time.strptime(expires_on, '%Y-%m-%d %H:%M:%S.%f') < time.gmtime()
+
     def _load_azure_token(self, provider):
         if 'config' not in provider:
             return
         if 'access-token' not in provider['config']:
             return
         if 'expires-on' in provider['config']:
-            if int(provider['config']['expires-on']) < time.gmtime():
+            if self._azure_is_expired(provider):
                 self._refresh_azure_token(provider['config'])
         self.token = 'Bearer %s' % provider['config']['access-token']
         return self.token


### PR DESCRIPTION
Fix bug by first checking if it is a digit

Add tests for:
* time str
* int
* illegal str
* illegal int

There were several pull requests on this, but none seem to have tests.

This should fix https://github.com/kubernetes-client/python-base/issues/84