### PR TITLE
Refs. #151 -- detect binary payloads and send the correct opcode

### DIFF
--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -116,7 +116,16 @@ class WSClient:
 
     def write_channel(self, channel, data):
         """Write data to a channel."""
-        self.sock.send(chr(channel) + data)
+        # check if we're writing binary data or not
+        binary = six.PY3 and type(data) == six.binary_type
+        opcode = ABNF.OPCODE_BINARY if binary else ABNF.OPCODE_TEXT
+
+        channel_prefix = chr(channel)
+        if binary:
+            channel_prefix = six.binary_type(channel_prefix, "ascii")
+
+        payload = channel_prefix + data
+        self.sock.send(payload, opcode=opcode)
 
     def peek_stdout(self, timeout=0):
         """Same as peek_channel with channel=1."""


### PR DESCRIPTION
On Python 2, strings are bytestrings either way. On Python 3, the
result of `chr(channel)` is `str`, while the data itself is
`bytes`. The channel prefix needs to be turned into a binary type,
and the websocket frame needs the correct opcode (binary vs. text).

See #151 for the bug report and related issues.

This is basically the same fix as #52 but with a different approach and passes the `opcode` argument to indicate a binary frame.