### PR TITLE
Remove all shebangs from Python modules and checker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for taking the time to join our community and start contributing!
 
-Any changes to utilites in this repo should be send as a PR to this repo.
+Any changes to utilities in this repo should be send as a PR to this repo.
 After the PR is merged, developers should create another PR in the main repo to update the submodule.
 See [this document](https://github.com/kubernetes-client/python/blob/master/devel/submodules.md) for more guidelines.
 
@@ -11,3 +11,19 @@ provides detailed instructions on how to get your ideas and bug fixes seen and a
 
 Please remember to sign the [CNCF CLA](https://github.com/kubernetes/community/blob/master/CLA.md) and
 read and observe the [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+## Adding new Python modules or Python scripts
+If you add a new Python module please make sure it includes the correct header
+as found in:
+```
+hack/boilerplate/boilerplate.py.txt
+```
+
+This module should not include a shebang line.
+
+If you add a new Python helper script intended for developers usage, it should
+go into the directory `hack` and include a shebang line `#!/usr/bin/env python`
+at the top in addition to rest of the boilerplate text as in all other modules.
+
+In addition this script's name should be added to the list   
+`SKIP_FILES`  at the top of hack/boilerplate/boilerplate.py.

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/config_exception.py
+++ b/config/config_exception.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/dateutil.py
+++ b/config/dateutil.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/dateutil_test.py
+++ b/config/dateutil_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/exec_provider.py
+++ b/config/exec_provider.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/exec_provider_test.py
+++ b/config/exec_provider_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/incluster_config.py
+++ b/config/incluster_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/incluster_config_test.py
+++ b/config/incluster_config_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/__init__.py
+++ b/dynamic/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/client.py
+++ b/dynamic/client.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/discovery.py
+++ b/dynamic/discovery.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/exceptions.py
+++ b/dynamic/exceptions.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/resource.py
+++ b/dynamic/resource.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -24,6 +24,10 @@ import os
 import re
 import sys
 
+# list all the files contain a shebang line and should be ignored by this
+# script
+SKIP_FILES = ['hack/boilerplate/boilerplate.py']
+
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "filenames",
@@ -132,10 +136,6 @@ def file_extension(filename):
     return os.path.splitext(filename)[1].split(".")[-1].lower()
 
 
-# list all the files contain 'DO NOT EDIT', but are not generated
-skipped_ungenerated_files = ['hack/boilerplate/boilerplate.py']
-
-
 def normalize_files(files):
     newfiles = []
     for pathname in files:
@@ -143,10 +143,12 @@ def normalize_files(files):
     for i, pathname in enumerate(newfiles):
         if not os.path.isabs(pathname):
             newfiles[i] = os.path.join(args.rootdir, pathname)
+
     return newfiles
 
 
 def get_files(extensions):
+
     files = []
     if len(args.filenames) > 0:
         files = args.filenames
@@ -163,6 +165,8 @@ def get_files(extensions):
         extension = file_extension(pathname)
         if extension in extensions or basename in extensions:
             outfiles.append(pathname)
+
+    outfiles = list(set(outfiles) - set(normalize_files(SKIP_FILES)))
     return outfiles
 
 

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright YEAR The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/stream/__init__.py
+++ b/stream/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/stream/stream.py
+++ b/stream/stream.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/stream/ws_client_test.py
+++ b/stream/ws_client_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/watch/__init__.py
+++ b/watch/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/watch/watch.py
+++ b/watch/watch.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/watch/watch_test.py
+++ b/watch/watch_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
As discussed, Python modules which aren't intended to be invoked
as scripts should not include a shebang line.