### PR TITLE
Use explicit API version for retrieving CRD API

### DIFF
--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -41,7 +41,9 @@ class TestDynamicClient(unittest.TestCase):
             changeme_api = client.resources.get(
                 api_version='apps.example.com/v1', kind='ClusterChangeMe')
 
-        crd_api = client.resources.get(kind='CustomResourceDefinition')
+        crd_api = client.resources.get(
+            api_version='apiextensions.k8s.io/v1beta1',
+            kind='CustomResourceDefinition')
         name = 'clusterchangemes.apps.example.com'
         crd_manifest = {
             'apiVersion': 'apiextensions.k8s.io/v1beta1',
@@ -138,7 +140,9 @@ class TestDynamicClient(unittest.TestCase):
             changeme_api = client.resources.get(
                 api_version='apps.example.com/v1', kind='ChangeMe')
 
-        crd_api = client.resources.get(kind='CustomResourceDefinition')
+        crd_api = client.resources.get(
+            api_version='apiextensions.k8s.io/v1beta1',
+            kind='CustomResourceDefinition')
         name = 'changemes.apps.example.com'
         crd_manifest = {
             'apiVersion': 'apiextensions.k8s.io/v1beta1',


### PR DESCRIPTION
This should fix the failing tests related to the dynamic client @micw523 feel free to pull this change in if you've got a PR fixing the other broken tests as well, I'm at a conference right now and haven't had the time to dig in

fixes part of https://github.com/kubernetes-client/python/issues/963