### PR TITLE
Migrate to pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,6 @@ envlist = py27, py35, py36, py37
 passenv = TOXENV CI TRAVIS TRAVIS_*
 commands =
    python -V
-   pip install nose
-   ./run_tox.sh nosetests []
+   pip install pytest
+   ./run_tox.sh pytest
 


### PR DESCRIPTION
As discussed previously, this replaces nose test runner with pytest.
This way there is a uniform toolset for python and python-base.