### PR TITLE
Fix azure refresh token apiserver id

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -249,12 +249,15 @@ class KubeConfigLoader(object):
         tenant = config['tenant-id']
         authority = 'https://login.microsoftonline.com/{}'.format(tenant)
         context = adal.AuthenticationContext(
-            authority, validate_authority=True,
+            authority, validate_authority=True, api_version='1.0'
         )
         refresh_token = config['refresh-token']
         client_id = config['client-id']
+        apiserver_id = config.get(
+            'apiserver-id',
+            '00000002-0000-0000-c000-000000000000')
         token_response = context.acquire_token_with_refresh_token(
-            refresh_token, client_id, '00000002-0000-0000-c000-000000000000')
+            refresh_token, client_id, apiserver_id)
 
         provider = self._user['auth-provider']['config']
         provider.value['access-token'] = token_response['accessToken']

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -458,6 +458,20 @@ class TestKubeConfigLoader(BaseTestCase):
                 }
             },
             {
+                "name": "azure_no_apiserver",
+                "context": {
+                    "cluster": "default",
+                    "user": "azure_no_apiserver"
+                }
+            },
+            {
+                "name": "azure_bad_apiserver",
+                "context": {
+                    "cluster": "default",
+                    "user": "azure_bad_apiserver"
+                }
+            },
+            {
                 "name": "expired_oidc",
                 "context": {
                     "cluster": "default",
@@ -647,7 +661,7 @@ class TestKubeConfigLoader(BaseTestCase):
                     "auth-provider": {
                         "config": {
                             "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
+                            "apiserver-id": "00000002-0000-0000-c000-000000000000",
                             "environment": "AzurePublicCloud",
                             "refresh-token": "refreshToken",
                             "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
@@ -662,7 +676,7 @@ class TestKubeConfigLoader(BaseTestCase):
                     "auth-provider": {
                         "config": {
                             "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
+                            "apiserver-id": "00000002-0000-0000-c000-000000000000",
                             "environment": "AzurePublicCloud",
                             "expires-in": "0",
                             "expires-on": "156207275",
@@ -679,7 +693,7 @@ class TestKubeConfigLoader(BaseTestCase):
                     "auth-provider": {
                         "config": {
                             "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
+                            "apiserver-id": "00000002-0000-0000-c000-000000000000",
                             "environment": "AzurePublicCloud",
                             "expires-in": "0",
                             "expires-on": "2018-10-18 00:52:29.044727",
@@ -696,7 +710,7 @@ class TestKubeConfigLoader(BaseTestCase):
                     "auth-provider": {
                         "config": {
                             "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
+                            "apiserver-id": "00000002-0000-0000-c000-000000000000",
                             "environment": "AzurePublicCloud",
                             "expires-in": "0",
                             "expires-on": "2018-10-18 00:52",
@@ -713,10 +727,43 @@ class TestKubeConfigLoader(BaseTestCase):
                     "auth-provider": {
                         "config": {
                             "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
+                            "apiserver-id": "00000002-0000-0000-c000-000000000000",
                             "environment": "AzurePublicCloud",
                             "expires-in": "0",
                             "expires-on": "-1",
+                            "refresh-token": "refreshToken",
+                            "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
+                        },
+                        "name": "azure"
+                    }
+                }
+            },
+            {
+                "name": "azure_no_apiserver",
+                "user": {
+                    "auth-provider": {
+                        "config": {
+                            "access-token": TEST_AZURE_TOKEN,
+                            "environment": "AzurePublicCloud",
+                            "expires-in": "0",
+                            "expires-on": "156207275",
+                            "refresh-token": "refreshToken",
+                            "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
+                        },
+                        "name": "azure"
+                    }
+                }
+            },
+            {
+                "name": "azure_bad_apiserver",
+                "user": {
+                    "auth-provider": {
+                        "config": {
+                            "access-token": TEST_AZURE_TOKEN,
+                            "apiserver-id": "ApiserverId",
+                            "environment": "AzurePublicCloud",
+                            "expires-in": "0",
+                            "expires-on": "156207275",
                             "refresh-token": "refreshToken",
                             "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
                         },
@@ -1046,6 +1093,22 @@ class TestKubeConfigLoader(BaseTestCase):
         )
         provider = loader._user['auth-provider']
         self.assertRaises(ValueError, loader._azure_is_expired, provider)
+
+    def test_azure_with_no_apiserver(self):
+        loader = KubeConfigLoader(
+            config_dict=self.TEST_KUBE_CONFIG,
+            active_context="azure_no_apiserver",
+        )
+        provider = loader._user['auth-provider']
+        self.assertTrue(loader._azure_is_expired(provider))
+
+    def test_azure_with_bad_apiserver(self):
+        loader = KubeConfigLoader(
+            config_dict=self.TEST_KUBE_CONFIG,
+            active_context="azure_bad_apiserver",
+        )
+        provider = loader._user['auth-provider']
+        self.assertTrue(loader._azure_is_expired(provider))
 
     def test_user_pass(self):
         expected = FakeConfig(host=TEST_HOST, token=TEST_BASIC_TOKEN)


### PR DESCRIPTION
Fixes #135 

Currently, the refresh token logic is hardcoded to use the general Microsoft Graph application id as the apiserver.  This fails if there's a mismatch in the kubeconfig, specifically in the audience in the access token being refreshed.  Instead, the new code will dynamically load this from the local kubeconfig as with the other request values and use that to submit the refresh call.

Additionally, this sets the ADAL API version to 1.0 to keep the behavior consistent with the kubernetes go client azure authentication flow.  (Namely, the string `spi:` being included for the audience)

I also updated the tests to use the Microsoft Graph app id as that was the prior behavior the tests were relying on.