### PR TITLE
Fixed Watch.unmarshal_event when data is not a JSON-serialized object

### DIFF
--- a/watch/watch.py
+++ b/watch/watch.py
@@ -88,6 +88,8 @@ class Watch(object):
             js = json.loads(data)
         except ValueError:
             return data
+        if not (isinstance(js, dict) and 'object' in js):
+            return data
         js['raw_object'] = js['object']
         if return_type:
             obj = SimpleNamespace(data=json.dumps(js['raw_object']))


### PR DESCRIPTION
Log streaming using Watch was introduced in https://github.com/kubernetes-client/python-base/pull/93/, but the users faced errors when the log line was a single number or an empty string.
This PR fixes those issues.

Fixes https://github.com/kubernetes-client/python/issues/982
Fixes https://github.com/kubernetes-client/python/issues/983