### PR TITLE
Adds Python 3.8 environment to Travis CI for running the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,35 +2,41 @@
 language: python
 dist: xenial
 
-matrix:
-    include:
-     - python: 2.7
-       env: TOXENV=py27
-     - python: 2.7
-       env: TOXENV=py27-functional
-     - python: 2.7
-       env: TOXENV=update-pycodestyle
-     - python: 3.7
-       env: TOXENV=docs
-     - python: 2.7
-       env: TOXENV=coverage,codecov
-     - python: 3.5
-       env: TOXENV=py35
-     - python: 3.5
-       env: TOXENV=py35-functional
-     - python: 3.6
-       env: TOXENV=py36
-     - python: 3.6
-       env: TOXENV=py36-functional
-     - python: 3.7
-       env: TOXENV=py37
-     - python: 3.7
-       env: TOXENV=py37-functional
+stages:
+  - verify boilerplate
+  - test
 
 install:
   - pip install tox
 
 script:
   - ./run_tox.sh tox
-  - ./hack/verify-boilerplate.sh
 
+jobs:
+  include:
+    - stage: verify boilerplate
+      script: ./hack/verify-boilerplate.sh
+      python: 3.7
+    - stage: test
+      python: 2.7
+      env: TOXENV=py27
+    - python: 2.7
+      env: TOXENV=py27-functional
+    - python: 2.7
+      env: TOXENV=update-pycodestyle
+    - python: 3.7
+      env: TOXENV=docs
+    - python: 2.7
+      env: TOXENV=coverage,codecov
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.5
+      env: TOXENV=py35-functional
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.6
+      env: TOXENV=py36-functional
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.7
+      env: TOXENV=py37-functional

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,7 @@ jobs:
       env: TOXENV=py37
     - python: 3.7
       env: TOXENV=py37-functional
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.8
+      env: TOXENV=py38-functional


### PR DESCRIPTION
Filed in response to https://github.com/kubernetes-client/python-base/pull/172#issuecomment-544648275

Reference: [Travis CI Supported Python Versions](https://docs.travis-ci.com/user/languages/python/#specifying-python-versions)