### PR TITLE
Fix apiserver_id 'get' method

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -326,9 +326,12 @@ class KubeConfigLoader(object):
         )
         refresh_token = config['refresh-token']
         client_id = config['client-id']
-        apiserver_id = config.get(
-            'apiserver-id',
-            '00000002-0000-0000-c000-000000000000')
+        apiserver_id = '00000002-0000-0000-c000-000000000000'
+        try:
+            apiserver_id = config['apiserver-id']
+        except ConfigException:
+            # We've already set a default above
+            pass
         token_response = context.acquire_token_with_refresh_token(
             refresh_token, client_id, apiserver_id)
 

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -461,20 +461,6 @@ class TestKubeConfigLoader(BaseTestCase):
                 }
             },
             {
-                "name": "azure_no_apiserver",
-                "context": {
-                    "cluster": "default",
-                    "user": "azure_no_apiserver"
-                }
-            },
-            {
-                "name": "azure_bad_apiserver",
-                "context": {
-                    "cluster": "default",
-                    "user": "azure_bad_apiserver"
-                }
-            },
-            {
                 "name": "expired_oidc",
                 "context": {
                     "cluster": "default",
@@ -764,39 +750,6 @@ class TestKubeConfigLoader(BaseTestCase):
                             "environment": "AzurePublicCloud",
                             "expires-in": "0",
                             "expires-on": "-1",
-                            "refresh-token": "refreshToken",
-                            "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
-                        },
-                        "name": "azure"
-                    }
-                }
-            },
-            {
-                "name": "azure_no_apiserver",
-                "user": {
-                    "auth-provider": {
-                        "config": {
-                            "access-token": TEST_AZURE_TOKEN,
-                            "environment": "AzurePublicCloud",
-                            "expires-in": "0",
-                            "expires-on": "156207275",
-                            "refresh-token": "refreshToken",
-                            "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
-                        },
-                        "name": "azure"
-                    }
-                }
-            },
-            {
-                "name": "azure_bad_apiserver",
-                "user": {
-                    "auth-provider": {
-                        "config": {
-                            "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
-                            "environment": "AzurePublicCloud",
-                            "expires-in": "0",
-                            "expires-on": "156207275",
                             "refresh-token": "refreshToken",
                             "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
                         },
@@ -1160,22 +1113,6 @@ class TestKubeConfigLoader(BaseTestCase):
         )
         provider = loader._user['auth-provider']
         self.assertRaises(ValueError, loader._azure_is_expired, provider)
-
-    def test_azure_with_no_apiserver(self):
-        loader = KubeConfigLoader(
-            config_dict=self.TEST_KUBE_CONFIG,
-            active_context="azure_no_apiserver",
-        )
-        provider = loader._user['auth-provider']
-        self.assertTrue(loader._azure_is_expired(provider))
-
-    def test_azure_with_bad_apiserver(self):
-        loader = KubeConfigLoader(
-            config_dict=self.TEST_KUBE_CONFIG,
-            active_context="azure_bad_apiserver",
-        )
-        provider = loader._user['auth-provider']
-        self.assertTrue(loader._azure_is_expired(provider))
 
     def test_user_pass(self):
         expected = FakeConfig(host=TEST_HOST, token=TEST_BASIC_TOKEN)


### PR DESCRIPTION
Fixes #179 

Not sure how I missed this in testing locally but ConfigNode definitely does not have a .get method.  This change instead relies on __getitem__ and it throwing a ConfigException to fall back to the default value.

This commit also prunes some excess tests that are already covered by other cases.