### PR TITLE
Adding ability to set kube config from a dict.

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -15,4 +15,4 @@
 from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
 from .kube_config import (list_kube_config_contexts, load_kube_config,
-                          new_client_from_config)
+                          new_client_from_config, load_kube_config_from_dict)

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -706,13 +706,34 @@ def _get_kube_config_loader_for_yaml_file(
         config_base_path=None,
         **kwargs)
 
+def _get_kube_config_loader(
+        filename=None,config_dict=None, persist_config=False, **kwargs):
+
+    if (config_dict is None):
+        kcfg = KubeConfigMerger(filename)
+        if persist_config and 'config_persister' not in kwargs:
+            kwargs['config_persister'] = kcfg.save_changes
+
+        if kcfg.config is None:
+            raise ConfigException(
+                'Invalid kube-config file. '
+                'No configuration found.')
+        return KubeConfigLoader(
+            config_dict=kcfg.config,
+            config_base_path=None,
+            **kwargs)
+    else:
+        return KubeConfigLoader(
+            config_dict=config_dict,
+            config_base_path=None,
+            **kwargs)
 
 def list_kube_config_contexts(config_file=None):
 
     if config_file is None:
         config_file = KUBE_CONFIG_DEFAULT_LOCATION
 
-    loader = _get_kube_config_loader_for_yaml_file(config_file)
+    loader = _get_kube_config_loader(filename=config_file)
     return loader.list_contexts(), loader.current_context
 
 
@@ -734,8 +755,8 @@ def load_kube_config(config_file=None, context=None,
     if config_file is None:
         config_file = KUBE_CONFIG_DEFAULT_LOCATION
 
-    loader = _get_kube_config_loader_for_yaml_file(
-        config_file, active_context=context,
+    loader = _get_kube_config_loader(
+        filename=config_file, active_context=context,
         persist_config=persist_config)
 
     if client_configuration is None:
@@ -745,6 +766,36 @@ def load_kube_config(config_file=None, context=None,
     else:
         loader.load_and_set(client_configuration)
 
+def load_kube_config_from_dict(config_dict, context=None,
+                     client_configuration=None,
+                     persist_config=True):
+    """Loads authentication and cluster information from kube-config file
+    and stores them in kubernetes.client.configuration.
+
+    :param config_dict: Takes the config file as a dict.
+    :param context: set the active context. If is set to None, current_context
+        from config file will be used.
+    :param client_configuration: The kubernetes.client.Configuration to
+        set configs to.
+    :param persist_config: If True, config file will be updated when changed
+        (e.g GCP token refresh).
+    """
+
+    if config_dict is None:
+        raise ConfigException(
+            'Invalid kube-config dict. '
+            'No configuration found.')
+
+    loader = _get_kube_config_loader(
+        config_dict=config_dict, active_context=context,
+        persist_config=persist_config)
+
+    if client_configuration is None:
+        config = type.__call__(Configuration)
+        loader.load_and_set(config)
+        Configuration.set_default(config)
+    else:
+        loader.load_and_set(client_configuration)
 
 def new_client_from_config(
         config_file=None,

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -760,7 +760,7 @@ def load_kube_config(config_file=None, context=None,
 def load_kube_config_from_dict(config_dict, context=None,
                      client_configuration=None,
                      persist_config=True):
-    """Loads authentication and cluster information from kube-config file
+    """Loads authentication and cluster information from config_dict file
     and stores them in kubernetes.client.configuration.
 
     :param config_dict: Takes the config file as a dict.

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -688,28 +688,19 @@ class KubeConfigMerger:
             yaml.safe_dump(self.config_files[path], f,
                            default_flow_style=False)
 
-
 def _get_kube_config_loader_for_yaml_file(
         filename, persist_config=False, **kwargs):
-
-    kcfg = KubeConfigMerger(filename)
-    if persist_config and 'config_persister' not in kwargs:
-        kwargs['config_persister'] = kcfg.save_changes
-
-    if kcfg.config is None:
-        raise ConfigException(
-            'Invalid kube-config file. '
-            'No configuration found.')
-
-    return KubeConfigLoader(
-        config_dict=kcfg.config,
-        config_base_path=None,
+    return _get_kube_config_loader(
+        filename=filename,
+        persist_config=persist_config,
         **kwargs)
 
 def _get_kube_config_loader(
-        filename=None,config_dict=None, persist_config=False, **kwargs):
-
-    if (config_dict is None):
+        filename=None,
+        config_dict=None,
+        persist_config=False,
+        **kwargs):
+    if config_dict is None:
         kcfg = KubeConfigMerger(filename)
         if persist_config and 'config_persister' not in kwargs:
             kwargs['config_persister'] = kcfg.save_changes

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1376,7 +1376,7 @@ class TestKubeConfigLoader(BaseTestCase):
     def test__get_kube_config_loader_dict_no_persist(self):
         expected = FakeConfig(host=TEST_HOST,
                               token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64)
-        actual = _get_kube_config_loader_for_yaml_file(
+        actual = _get_kube_config_loader(
             config_dict=self.TEST_KUBE_CONFIG)
         self.assertIsNone(actual._config_persister)
 

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1380,15 +1380,6 @@ class TestKubeConfigLoader(BaseTestCase):
             config_dict=self.TEST_KUBE_CONFIG)
         self.assertIsNone(actual._config_persister)
 
-    def test__get_kube_config_loader_dict_persist(self):
-        expected = FakeConfig(host=TEST_HOST,
-                              token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64)
-        actual = _get_kube_config_loader(config_dict=self.TEST_KUBE_CONFIG,
-                                         persist_config=True)
-        self.assertTrue(callable(actual._config_persister))
-        self.assertEquals(actual._config_persister.__name__, "save_changes")
-
-
 class TestKubernetesClientConfiguration(BaseTestCase):
     # Verifies properties of kubernetes.client.Configuration.
     # These tests guard against changes to the upstream configuration class,

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -33,11 +33,10 @@ from .kube_config import (ENV_KUBECONFIG_PATH_SEPARATOR, CommandTokenSource,
                           ConfigNode, FileOrData, KubeConfigLoader,
                           KubeConfigMerger, _cleanup_temp_files,
                           _create_temp_file_with_content,
-                          _get_kube_config_loader_for_yaml_file,
                           _get_kube_config_loader,
+                          _get_kube_config_loader_for_yaml_file,
                           list_kube_config_contexts, load_kube_config,
-                          load_kube_config_from_dict,
-                          new_client_from_config)
+                          load_kube_config_from_dict, new_client_from_config)
 
 BEARER_TOKEN_FORMAT = "Bearer %s"
 
@@ -1237,8 +1236,8 @@ class TestKubeConfigLoader(BaseTestCase):
 
         actual = FakeConfig()
         load_kube_config_from_dict(config_dict=self.TEST_KUBE_CONFIG,
-                         context="simple_token",
-                         client_configuration=actual)
+                                   context="simple_token",
+                                   client_configuration=actual)
         self.assertEqual(expected, actual)
 
     def test_list_kube_config_contexts(self):
@@ -1370,24 +1369,24 @@ class TestKubeConfigLoader(BaseTestCase):
         config_file = self._create_temp_file(
             yaml.safe_dump(self.TEST_KUBE_CONFIG))
         actual = _get_kube_config_loader(filename=config_file,
-                                                       persist_config=True)
+                                         persist_config=True)
         self.assertTrue(callable(actual._config_persister))
         self.assertEquals(actual._config_persister.__name__, "save_changes")
 
     def test__get_kube_config_loader_dict_no_persist(self):
         expected = FakeConfig(host=TEST_HOST,
                               token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64)
-        actual = _get_kube_config_loader_for_yaml_file(config_dict=self.TEST_KUBE_CONFIG)
+        actual = _get_kube_config_loader_for_yaml_file(
+            config_dict=self.TEST_KUBE_CONFIG)
         self.assertIsNone(actual._config_persister)
 
     def test__get_kube_config_loader_dict_persist(self):
         expected = FakeConfig(host=TEST_HOST,
                               token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64)
         actual = _get_kube_config_loader(config_dict=self.TEST_KUBE_CONFIG,
-                                                       persist_config=True)
+                                         persist_config=True)
         self.assertTrue(callable(actual._config_persister))
         self.assertEquals(actual._config_persister.__name__, "save_changes")
-
 
 
 class TestKubernetesClientConfiguration(BaseTestCase):


### PR DESCRIPTION
Added a function called `load_kube_config_from_dict()`, adding the ability to set the `~/.kube/config` file from a dict.

Required where kubeconfig is stored externally and saving to disk is not an option.

#### Usage 
```
import yaml
import kubernetes
from os.path import expanduser
config_dict = yaml.load(expanduser("~") + "/.kube/config")
kubernetes.config.load_kube_config_from_dict(config_dict)
```