### PR TITLE
Watch while maintaining the distinction between stdout and stderr

### DIFF
--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -144,7 +144,7 @@ class WSClient:
                         continue
                     if "\n" in data:
                         index = data.find("\n")
-                        ret = {"channel": channel, data: data[:index]}
+                        ret = {"channel": channel, "data": data[:index]}
                         data = data[index+1:]
                         if data:
                             self._channels[channel] = data


### PR DESCRIPTION
Added a function called `readline_any` that reads from any channel (`stdout` and `stderr` by default), while returning the information of which channel outputed the given line. 
Consuming this method allows to have all the outputs from the stream, their order, and to which channel they were submitted. 