### PR TITLE
fix cfg is none, load kube config error

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -663,9 +663,8 @@ class KubeConfigMerger:
             for item in ('clusters', 'contexts', 'users'):
                 config_merged[item] = []
             self.config_merged = ConfigNode(path, config_merged, path)
-
         for item in ('clusters', 'contexts', 'users'):
-            self._merge(item, config.get(item, {}), path)
+            self._merge(item, config.get(item, []) or [], path)
         self.config_files[path] = config
 
     def _merge(self, item, add_cfg, path):

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1342,7 +1342,7 @@ class TestKubeConfigLoader(BaseTestCase):
         actual = _get_kube_config_loader_for_yaml_file(config_file,
                                                        persist_config=True)
         self.assertTrue(callable(actual._config_persister))
-        self.assertEquals(actual._config_persister.__name__, "save_changes")
+        self.assertEqual(actual._config_persister.__name__, "save_changes")
 
 
 class TestKubernetesClientConfiguration(BaseTestCase):
@@ -1517,6 +1517,26 @@ class TestKubeConfigMerger(BaseTestCase):
             }
         ]
     }
+    TEST_KUBE_CONFIG_PART6 = {
+        "current-context": "no_user",
+        "contexts": [
+            {
+                "name": "no_user",
+                "context": {
+                    "cluster": "default"
+                }
+            },
+        ],
+        "clusters": [
+            {
+                "name": "default",
+                "cluster": {
+                    "server": TEST_HOST
+                }
+            },
+        ],
+        "users": None
+    }
 
     def _create_multi_config(self):
         files = []
@@ -1525,7 +1545,8 @@ class TestKubeConfigMerger(BaseTestCase):
                 self.TEST_KUBE_CONFIG_PART2,
                 self.TEST_KUBE_CONFIG_PART3,
                 self.TEST_KUBE_CONFIG_PART4,
-                self.TEST_KUBE_CONFIG_PART5):
+                self.TEST_KUBE_CONFIG_PART5,
+                self.TEST_KUBE_CONFIG_PART6):
             files.append(self._create_temp_file(yaml.safe_dump(part)))
         return ENV_KUBECONFIG_PATH_SEPARATOR.join(files)
 


### PR DESCRIPTION
This PR fixed
https://github.com/kubernetes/kubernetes/pull/84503 changed the behaviour of kubectl config unset slightly that if no users left in kubeconfig after user run kubectl config unset users.<user>, the value of users field in kubeconfig would be set to null rather than [].

since users set to null,  kubernetes.config.kube_config.load_kube_config() can't work, this pr set a default empty list to users

Which issue(s) this PR fixes:

Try to fixes
https://github.com/kubernetes-client/python-base/issues/183
https://github.com/kubernetes-client/python-base/issues/181