### PR TITLE
resource version reset default when event object resource version inv…

### DIFF
--- a/watch/watch.py
+++ b/watch/watch.py
@@ -97,6 +97,10 @@ class Watch(object):
                   and 'resourceVersion' in js['object']['metadata']):
                 self.resource_version = js['object']['metadata'][
                     'resourceVersion']
+            if self.resource_version is None:
+                # In some case like 'too old resource version',
+                # the event type would be ERROR, resource version will be None
+                self.resource_version = 0
         return js
 
     def stream(self, func, *args, **kwargs):


### PR DESCRIPTION
Watch an API resource and stream the result back via a generator, when resource_version specified,  may be cause "too old resource version" error, then result would be:
`{
    "type":"ERROR",
    "object":{
        "kind":"Status",
        "apiVersion":"v1",
        "metadata":{
        },
        "status":"Failure",
        "message":"too old resource version: 38081900 (64845263)",
        "reason":"Gone",
        "code":410
    }
}
`
In this case, the func unmarshal_event can not parse the right  resource version, actually is None,
the stream while loop continue, the next request will get ApiException: (500) error:
`HTTP response headers: HTTPHeaderDict({'Content-Length': '186', 'Content-Type': 'application/json', 'Date': 'Fri, 19 Jun 2020 06:21:06 GMT'})
HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"resourceVersion: Invalid value: \\"None\\": strconv.ParseUint: parsing \\"None\\": invalid syntax","code":500}\n'`