### PR TITLE
Run scripts/update-pycodestyle.sh to fix the pycodestyle test failure

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -15,4 +15,4 @@
 from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
 from .kube_config import (list_kube_config_contexts, load_kube_config,
-                          new_client_from_config, load_kube_config_from_dict)
+                          load_kube_config_from_dict, new_client_from_config)

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -688,12 +688,14 @@ class KubeConfigMerger:
             yaml.safe_dump(self.config_files[path], f,
                            default_flow_style=False)
 
+
 def _get_kube_config_loader_for_yaml_file(
         filename, persist_config=False, **kwargs):
     return _get_kube_config_loader(
         filename=filename,
         persist_config=persist_config,
         **kwargs)
+
 
 def _get_kube_config_loader(
         filename=None,
@@ -718,6 +720,7 @@ def _get_kube_config_loader(
             config_dict=config_dict,
             config_base_path=None,
             **kwargs)
+
 
 def list_kube_config_contexts(config_file=None):
 
@@ -757,9 +760,10 @@ def load_kube_config(config_file=None, context=None,
     else:
         loader.load_and_set(client_configuration)
 
+
 def load_kube_config_from_dict(config_dict, context=None,
-                     client_configuration=None,
-                     persist_config=True):
+                               client_configuration=None,
+                               persist_config=True):
     """Loads authentication and cluster information from config_dict file
     and stores them in kubernetes.client.configuration.
 
@@ -787,6 +791,7 @@ def load_kube_config_from_dict(config_dict, context=None,
         Configuration.set_default(config)
     else:
         loader.load_and_set(client_configuration)
+
 
 def new_client_from_config(
         config_file=None,

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1380,6 +1380,7 @@ class TestKubeConfigLoader(BaseTestCase):
             config_dict=self.TEST_KUBE_CONFIG)
         self.assertIsNone(actual._config_persister)
 
+
 class TestKubernetesClientConfiguration(BaseTestCase):
     # Verifies properties of kubernetes.client.Configuration.
     # These tests guard against changes to the upstream configuration class,


### PR DESCRIPTION
Due to the issue with travis not reporting job result back, https://github.com/kubernetes-client/python-base/pull/195 was merged with a [pycodestyle test failure](https://travis-ci.org/github/kubernetes-client/python-base/builds/700186487). 

This PR runs [scripts/update-pycodestyle.sh](https://github.com/kubernetes-client/python/blob/master/scripts/update-pycodestyle.sh) to fix the test. 

/cc @palnabarun @vishnu667