### PR TITLE
Add old api_key to set auth attributes

### DIFF
--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1399,11 +1399,13 @@ class TestKubernetesClientConfiguration(BaseTestCase):
 
     def test_auth_settings_calls_get_api_key_with_prefix(self):
         expected_token = 'expected_token'
+        old_token = 'old_token'
 
         def fake_get_api_key_with_prefix(identifier):
             self.assertEqual('authorization', identifier)
             return expected_token
         config = Configuration()
+        config.api_key['authorization'] = old_token
         config.get_api_key_with_prefix = fake_get_api_key_with_prefix
         self.assertEqual(expected_token,
                          config.auth_settings()['BearerToken']['value'])


### PR DESCRIPTION
fixes https://github.com/kubernetes-client/python/pull/1188#issuecomment-659207213

Add "authorization" to api_key with a old token, so that Configuration returns the overwritten auth attributes. 

/assign @palnabarun 