### PR TITLE
Fix windows error when using ExecProvider

### DIFF
--- a/config/exec_provider.py
+++ b/config/exec_provider.py
@@ -70,7 +70,8 @@ class ExecProvider(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env=self.env,
-            universal_newlines=True)
+            universal_newlines=True,
+            shell=True)
         (stdout, stderr) = process.communicate()
         exit_code = process.wait()
         if exit_code != 0:


### PR DESCRIPTION
Popen expect a list of strings for non-shell calls and a string for shell calls.
Solution: run `subprocess.Popen()` with `shell = True` . 


Related error: `WindowsError: [Error 2] The system cannot find the file specified`
Related issue: https://bugs.python.org/issue17023
