### PR TITLE
do-not-merge: run dynamic client e2e test and verify the exception

### DIFF
--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -81,6 +81,8 @@ class TestDynamicClient(unittest.TestCase):
             changeme_api = client.resources.get(
                 api_version='apps.example.com/v1', kind='ClusterChangeMe')
         except ResourceNotFoundError:
+            # do-not-merge: trigger the e2e test to make sure the failure is
+            # caught by the test
             # Need to wait a sec for the discovery layer to get updated
             time.sleep(2)
         changeme_api = client.resources.get(


### PR DESCRIPTION
make sure the same test failure gets caught: https://github.com/kubernetes-client/python/pull/1281

Note that the failure is flaky, since the client won't raise exception if the discovery is already updated. It only fails when a retry is needed. 

/hold