### PR TITLE
dynamic-e2e: fix the error expectation in the discovery retry logic

### DIFF
--- a/dynamic/discovery.py
+++ b/dynamic/discovery.py
@@ -254,8 +254,11 @@ class LazyDiscoverer(Discoverer):
                 # Check if we've requested resources for this group
                 if not resourcePart.resources:
                     prefix, group, version = reqParams[0], reqParams[1], part
-                    resourcePart.resources = self.get_resources_for_api_version(
-                        prefix, group, part, resourcePart.preferred)
+                    try:
+                        resourcePart.resources = self.get_resources_for_api_version(
+                            prefix, group, part, resourcePart.preferred)
+                    except NotFoundError:
+                        raise ResourceNotFoundError
 
                     self._cache['resources'][prefix][group][version] = resourcePart
                     self.__update_cache = True


### PR DESCRIPTION
fixes the flake in https://github.com/kubernetes-client/python/pull/1281. 

With https://github.com/kubernetes-client/python-base/pull/187, the meta_request now raises `NotFoundError` instead of `ResourceNotFoundError` if discovery doc is not ready. 