### PR TITLE
configmap e2e: use labels and label selector

### DIFF
--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -331,6 +331,9 @@ class TestDynamicClient(unittest.TestCase):
             "apiVersion": "v1",
             "metadata": {
                 "name": name,
+                "labels": {
+                    "e2e-test": "true",
+                },
             },
             "data": {
                 "config.json": "{\"command\":\"/usr/bin/mysqld_safe\"}",
@@ -344,7 +347,7 @@ class TestDynamicClient(unittest.TestCase):
         self.assertEqual(name, resp.metadata.name)
 
         resp = api.get(
-            name=name, namespace='default')
+            name=name, namespace='default', label_selector="e2e-test=true")
         self.assertEqual(name, resp.metadata.name)
 
         test_configmap['data']['config.json'] = "{}"
@@ -354,7 +357,7 @@ class TestDynamicClient(unittest.TestCase):
         resp = api.delete(
             name=name, body={}, namespace='default')
 
-        resp = api.get(namespace='default', pretty=True)
+        resp = api.get(namespace='default', pretty=True, label_selector="e2e-test=true")
         self.assertEqual([], resp.items)
 
     def test_node_apis(self):


### PR DESCRIPTION
The [Bound Service Account Tokens](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md) feature creates a configmap `kube-root-ca.crt` in every namespace. Use a label to select the test objects we create. 

/hold
wait for the tests to pass