### PR TITLE
raise exception when an empty config file is passed to load_kube_config

### DIFF
--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -682,6 +682,9 @@ class KubeConfigMerger:
         else:
             config = yaml.safe_load(string.read())
 
+        if config is None:
+            raise ConfigException(
+                'Invalid kube-config.')
         if self.config_merged is None:
             self.config_merged = copy.deepcopy(config)
         # doesn't need to do any further merging
@@ -698,6 +701,11 @@ class KubeConfigMerger:
     def load_config(self, path):
         with open(path) as f:
             config = yaml.safe_load(f)
+
+        if config is None:
+            raise ConfigException(
+                'Invalid kube-config. '
+                '%s file is empty' % path)
 
         if self.config_merged is None:
             config_merged = copy.deepcopy(config)

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1290,6 +1290,15 @@ class TestKubeConfigLoader(BaseTestCase):
                                    client_configuration=actual)
         self.assertEqual(expected, actual)
 
+    def test_load_kube_config_from_empty_file(self):
+        config_file_like_object = io.StringIO()
+        self.assertRaises(ConfigException, load_kube_config, config_file_like_object)
+
+    def test_load_kube_config_from_empty_file_like_object(self):
+        config_file = self._create_temp_file(
+            yaml.safe_dump(None))
+        self.assertRaises(ConfigException, load_kube_config, config_file)
+
     def test_list_kube_config_contexts(self):
         config_file = self._create_temp_file(
             yaml.safe_dump(self.TEST_KUBE_CONFIG))

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1292,12 +1292,18 @@ class TestKubeConfigLoader(BaseTestCase):
 
     def test_load_kube_config_from_empty_file(self):
         config_file_like_object = io.StringIO()
-        self.assertRaises(ConfigException, load_kube_config, config_file_like_object)
+        self.assertRaises(
+            ConfigException,
+            load_kube_config,
+            config_file_like_object)
 
     def test_load_kube_config_from_empty_file_like_object(self):
         config_file = self._create_temp_file(
             yaml.safe_dump(None))
-        self.assertRaises(ConfigException, load_kube_config, config_file)
+        self.assertRaises(
+            ConfigException,
+            load_kube_config,
+            config_file)
 
     def test_list_kube_config_contexts(self):
         config_file = self._create_temp_file(

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1290,14 +1290,14 @@ class TestKubeConfigLoader(BaseTestCase):
                                    client_configuration=actual)
         self.assertEqual(expected, actual)
 
-    def test_load_kube_config_from_empty_file(self):
+    def test_load_kube_config_from_empty_file_like_object(self):
         config_file_like_object = io.StringIO()
         self.assertRaises(
             ConfigException,
             load_kube_config,
             config_file_like_object)
 
-    def test_load_kube_config_from_empty_file_like_object(self):
+    def test_load_kube_config_from_empty_file(self):
         config_file = self._create_temp_file(
             yaml.safe_dump(None))
         self.assertRaises(


### PR DESCRIPTION
`load_kube_config` currently fails with a nondescript `TypeError: 'NoneType'` error if an empty kube_config file is used.

Error log
```
~/miniconda3/envs/dask/lib/python3.8/site-packages/kubernetes/config/kube_config.py in load_kube_config(config_file, context, client_configuration, persist_config)
    790         config_file = KUBE_CONFIG_DEFAULT_LOCATION
    791
--> 792     loader = _get_kube_config_loader(
    793         filename=config_file, active_context=context,
    794         persist_config=persist_config)

~/miniconda3/envs/dask/lib/python3.8/site-packages/kubernetes/config/kube_config.py in _get_kube_config_loader(filename, config_dict, persist_config, **kwargs)
    744         **kwargs):
    745     if config_dict is None:
--> 746         kcfg = KubeConfigMerger(filename)
    747         if persist_config and 'config_persister' not in kwargs:
    748             kwargs['config_persister'] = kcfg.save_changes

~/miniconda3/envs/dask/lib/python3.8/site-packages/kubernetes/config/kube_config.py in __init__(self, paths)
    671             self._load_config_from_file_like_object(paths)
    672         else:
--> 673             self._load_config_from_file_path(paths)
    674
    675     @property

~/miniconda3/envs/dask/lib/python3.8/site-packages/kubernetes/config/kube_config.py in _load_config_from_file_path(self, string)
    693                 if os.path.exists(path):
    694                     self.paths.append(path)
--> 695                     self.load_config(path)
    696         self.config_saved = copy.deepcopy(self.config_files)
    697

~/miniconda3/envs/dask/lib/python3.8/site-packages/kubernetes/config/kube_config.py in load_config(self, path)
    703             config_merged = copy.deepcopy(config)
    704             for item in ('clusters', 'contexts', 'users'):
--> 705                 config_merged[item] = []
    706             self.config_merged = ConfigNode(path, config_merged, path)
    707         for item in ('clusters', 'contexts', 'users'):

TypeError: 'NoneType' object does not support item assignment
```

I have added a check to raise a `ConfigException` error if an empty file is encountered.