### PR TITLE
Remove inactive members from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - mbohlool
   - yliaog
   - roycaihw
+emeritus_approvers:
+  - mbohlool
+


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months) from OWNERS files, this commit moves mbohlool from
an approver to emeritus_approver.