### PR TITLE
Fix trivial typo in error messages

### DIFF
--- a/config/incluster_config.py
+++ b/config/incluster_config.py
@@ -70,13 +70,13 @@ class InClusterConfigLoader(object):
                                      self._environ[SERVICE_PORT_ENV_NAME]))
 
         if not os.path.isfile(self._token_filename):
-            raise ConfigException("Service token file does not exists.")
+            raise ConfigException("Service token file does not exist.")
 
         self._read_token_file()
 
         if not os.path.isfile(self._cert_filename):
             raise ConfigException(
-                "Service certification file does not exists.")
+                "Service certification file does not exist.")
 
         with open(self._cert_filename) as f:
             if not f.read():

--- a/config/incluster_config_test.py
+++ b/config/incluster_config_test.py
@@ -142,7 +142,7 @@ class InClusterConfigTest(unittest.TestCase):
 
     def test_no_cert_file(self):
         loader = self.get_test_loader(cert_filename="not_exists_file_1123")
-        self._should_fail_load(loader, "cert file does not exists")
+        self._should_fail_load(loader, "cert file does not exist")
 
     def test_empty_cert_file(self):
         loader = self.get_test_loader(
@@ -151,7 +151,7 @@ class InClusterConfigTest(unittest.TestCase):
 
     def test_no_token_file(self):
         loader = self.get_test_loader(token_filename="not_exists_file_1123")
-        self._should_fail_load(loader, "token file does not exists")
+        self._should_fail_load(loader, "token file does not exist")
 
     def test_empty_token_file(self):
         loader = self.get_test_loader(

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -120,7 +120,7 @@ class FileOrData(object):
             else:
                 self._file = _create_temp_file_with_content(self._data)
         if self._file and not os.path.isfile(self._file):
-            raise ConfigException("File does not exists: %s" % self._file)
+            raise ConfigException("File does not exist: %s" % self._file)
         return self._file
 
     def as_data(self):

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -178,7 +178,7 @@ class TestFileOrData(BaseTestCase):
         temp_filename = NON_EXISTING_FILE
         obj = {TEST_FILE_KEY: temp_filename}
         t = FileOrData(obj=obj, file_key_name=TEST_FILE_KEY)
-        self.expect_exception(t.as_file, "does not exists")
+        self.expect_exception(t.as_file, "does not exist")
 
     def test_file_given_data(self):
         obj = {TEST_DATA_KEY: TEST_DATA_BASE64}
@@ -1165,7 +1165,7 @@ class TestKubeConfigLoader(BaseTestCase):
             active_context="ssl-no_file")
         self.expect_exception(
             loader.load_and_set,
-            "does not exists",
+            "does not exist",
             FakeConfig())
 
     def test_ssl(self):


### PR DESCRIPTION
Fix trivial typo in error messages - 'does not exist' vs. 'does not exists'.