### PR TITLE
Fixes kubernetes-client/python issue 1047 "ResponseNotChunked from watch"

### DIFF
--- a/watch/watch.py
+++ b/watch/watch.py
@@ -53,7 +53,7 @@ def _find_return_type(func):
 
 def iter_resp_lines(resp):
     prev = ""
-    for seg in resp.read_chunked(decode_content=False):
+    for seg in resp.stream(amt=None, decode_content=False):
         if isinstance(seg, bytes):
             seg = seg.decode('utf8')
         seg = prev + seg


### PR DESCRIPTION
In recent versions of K8S (>1.16?), when a `Watch.stream()` call uses a
resource_version which is too old the resulting 410 error is wrapped in JSON
and returned in a non-chunked 200 response. Using `resp.stream()` instead of
`resp.read_chunked()` automatically handles the response being either chunked or
non-chunked.