### PR TITLE
Support customizing “Accept” header #1428

### DIFF
--- a/dynamic/client.py
+++ b/dynamic/client.py
@@ -219,11 +219,14 @@ class DynamicClient(object):
         header_params = params.get('header_params', {})
         form_params = []
         local_var_files = {}
-        # HTTP header `Accept`
-        header_params['Accept'] = self.client.select_header_accept([
-            'application/json',
-            'application/yaml',
-        ])
+
+        # Checking Accept header.
+        new_header_params = dict((key.lower(), value) for key, value in header_params.items())
+        if not 'accept' in new_header_params:
+            header_params['Accept'] = self.client.select_header_accept([
+                'application/json',
+                'application/yaml',
+            ])
 
         # HTTP header `Content-Type`
         if params.get('content_type'):

--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -359,7 +359,7 @@ class TestDynamicClient(unittest.TestCase):
 
         resp = api.get(namespace='default', pretty=True, label_selector="e2e-test=true")
         self.assertEqual([], resp.items)
-
+    
     def test_node_apis(self):
         client = DynamicClient(api_client.ApiClient(configuration=self.config))
         api = client.resources.get(api_version='v1', kind='Node')
@@ -367,3 +367,19 @@ class TestDynamicClient(unittest.TestCase):
         for item in api.get().items:
             node = api.get(name=item.metadata.name)
             self.assertTrue(len(dict(node.metadata.labels)) > 0)
+    
+    # test_node_apis_partial_object_metadata lists all nodes in the cluster, but only retrieves object metadata
+    def test_node_apis_partial_object_metadata(self):
+        client = DynamicClient(api_client.ApiClient(configuration=self.config))
+        api = client.resources.get(api_version='v1', kind='Node')
+        
+        params = {'header_params': {'Accept': 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io'}}
+        resp = api.get(**params)
+        self.assertEqual('PartialObjectMetadataList', resp.kind)
+        self.assertEqual('meta.k8s.io/v1', resp.apiVersion)
+
+        params = {'header_params': {'aCcePt': 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io'}}
+        resp = api.get(**params)
+        self.assertEqual('PartialObjectMetadataList', resp.kind)
+        self.assertEqual('meta.k8s.io/v1', resp.apiVersion)
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

####
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We are adding the new header parameter in the dynamic client which helps in scenarios where the user only cares about object metadata and wants to reduce the client-side deserialisation time.

This changes will accept the header like `'application/json;as=PartialObjectMetadata;v=v1;g=meta.k8s.io'` or `'application/json;as=Table;v=v1;g=meta.k8s.io'`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1428

#### Special notes for your reviewer:
Added the metadata field which is currently present in [client-go](https://github.com/kubernetes/client-go/blob/master/metadata/metadata.go#L162). Now this feature will also be supporting in the python-client.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The dynamic client now supports customizing http "Accept" header through the `header_params` parameter, which can be used to customizing API server response, e.g. retrieving object metadata only. 
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
