### PR TITLE
drop python2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,12 @@ jobs:
       script: ./hack/verify-boilerplate.sh
       python: 3.7
     - stage: test
-      python: 2.7
-      env: TOXENV=py27
-    - python: 2.7
-      env: TOXENV=py27-functional
-    - python: 2.7
+      python: 3.9
       env: TOXENV=update-pycodestyle
+    - python: 3.9
+      env: TOXENV=coverage,codecov
     - python: 3.7
       env: TOXENV=docs
-    - python: 2.7
-      env: TOXENV=coverage,codecov
     - python: 3.5
       env: TOXENV=py35
     - python: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
 envlist =
-   py27, py3{5,6,7,8,9}
-   py27-functional, py3{5,6,7,8,9}-functional
+   py3{5,6,7,8,9}
+   py3{5,6,7,8,9}-functional
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind clean-up

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The PR makes changes to drop support for Python 2 from the next release (v18.0.0). The changes includes:
- [X] drop Python 2 from master branch
- [X] make sure all the tests use Python 3

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-client/python/issues/1413

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The `python2` support will be removed in 18.0.0 beta release. All the tests will use `python3` versions.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes-client/python/blob/master/CHANGELOG.md#v1700-snapshot
```
Signed-off-by: Priyanka Saggu <priyankasaggu11929@gmail.com>