### PR TITLE
Make duck-typing checking in `serialize_body` method more restrictive

### DIFF
--- a/dynamic/client.py
+++ b/dynamic/client.py
@@ -98,7 +98,12 @@ class DynamicClient(object):
         return namespace
 
     def serialize_body(self, body):
-        if hasattr(body, 'to_dict'):
+        """Serialize body to raw dict so apiserver can handle it
+
+        :param body: kubernetes resource body, current support: Union[Dict, ResourceInstance]
+        """
+        # This should match any `ResourceInstance` instances
+        if callable(getattr(body, 'to_dict', None)):
             return body.to_dict()
         return body or {}
 


### PR DESCRIPTION
The`body` parameter in `DynamicClient`'s most methods currently accepts both dict type and `ResourceInstance` type. This was achieved by calling `serialize_body()` before mading any requests.

But in current implementation, the duck-typing style checking in `serialize_body` was kind of meaning-less---`ResourceInstance` type has overwritten it's `__getattr__` method, so basically it's instances can pass every `hasattr(...)` check.

```python
>>> inst = ResourceInstance(None, {'kind': 'Pod'})
>>> hasattr(inst, 'to_dict')
True
>>> hasattr(inst, 'to_dict_whatever_name')
True
```

This PR makes the checking in `serialize_body()` method more restrictive and also add some related unit tests.

### Release Note: 

```release-note
Type checking in `Client.serialize_body()` was made more restrictive and robust.
```
