### PR TITLE
fix: Ignore NotFoundError in the first call of LazyDiscoverer. __search

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,72 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
+2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
+https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
+3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
+4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+-->
+
+#### What type of PR is this?
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
+
+#### What this PR does / why we need it:
+
+#### Which issue(s) this PR fixes:
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
+-->
+Fixes #
+
+#### Special notes for your reviewer:
+
+#### Does this PR introduce a user-facing change?
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+
+For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
+-->
+```release-note
+
+```
+
+#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
+
+<!--
+This section can be blank if this pull request does not require a release note.
+
+When adding links which point to resources within git repositories, like
+KEPs or supporting documentation, please reference a specific commit and avoid
+linking directly to the master branch. This ensures that links reference a
+specific point in time, rather than a document that may change over time.
+
+See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files
+
+Please use the following format for linking documentation:
+- [KEP]: <link>
+- [Usage]: <link>
+- [Other doc]: <link>
+-->
+```docs
+
+```

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # ref: https://docs.travis-ci.com/user/languages/python
 language: python
 dist: xenial
-sudo: required
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
        env: TOXENV=py27-functional
      - python: 2.7
        env: TOXENV=update-pycodestyle
-     - python: 2.7
+     - python: 3.7
        env: TOXENV=docs
      - python: 2.7
        env: TOXENV=coverage,codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,7 @@ jobs:
       env: TOXENV=py38
     - python: 3.8
       env: TOXENV=py38-functional
+    - python: 3.9
+      env: TOXENV=py39
+    - python: 3.9
+      env: TOXENV=py39-functional

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,12 @@ jobs:
       script: ./hack/verify-boilerplate.sh
       python: 3.7
     - stage: test
-      python: 2.7
-      env: TOXENV=py27
-    - python: 2.7
-      env: TOXENV=py27-functional
-    - python: 2.7
+      python: 3.9
       env: TOXENV=update-pycodestyle
+    - python: 3.9
+      env: TOXENV=coverage,codecov
     - python: 3.7
       env: TOXENV=docs
-    - python: 2.7
-      env: TOXENV=coverage,codecov
     - python: 3.5
       env: TOXENV=py35
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
        env: TOXENV=docs
      - python: 2.7
        env: TOXENV=coverage,codecov
-     - python: 3.4
-       env: TOXENV=py34
      - python: 3.5
        env: TOXENV=py35
      - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,35 +2,41 @@
 language: python
 dist: xenial
 
-matrix:
-    include:
-     - python: 2.7
-       env: TOXENV=py27
-     - python: 2.7
-       env: TOXENV=py27-functional
-     - python: 2.7
-       env: TOXENV=update-pycodestyle
-     - python: 3.7
-       env: TOXENV=docs
-     - python: 2.7
-       env: TOXENV=coverage,codecov
-     - python: 3.5
-       env: TOXENV=py35
-     - python: 3.5
-       env: TOXENV=py35-functional
-     - python: 3.6
-       env: TOXENV=py36
-     - python: 3.6
-       env: TOXENV=py36-functional
-     - python: 3.7
-       env: TOXENV=py37
-     - python: 3.7
-       env: TOXENV=py37-functional
+stages:
+  - verify boilerplate
+  - test
 
 install:
   - pip install tox
 
 script:
   - ./run_tox.sh tox
-  - ./hack/verify-boilerplate.sh
 
+jobs:
+  include:
+    - stage: verify boilerplate
+      script: ./hack/verify-boilerplate.sh
+      python: 3.7
+    - stage: test
+      python: 2.7
+      env: TOXENV=py27
+    - python: 2.7
+      env: TOXENV=py27-functional
+    - python: 2.7
+      env: TOXENV=update-pycodestyle
+    - python: 3.7
+      env: TOXENV=docs
+    - python: 2.7
+      env: TOXENV=coverage,codecov
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.5
+      env: TOXENV=py35-functional
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.6
+      env: TOXENV=py36-functional
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.7
+      env: TOXENV=py37-functional

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,7 @@ jobs:
       env: TOXENV=py37
     - python: 3.7
       env: TOXENV=py37-functional
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.8
+      env: TOXENV=py38-functional

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for taking the time to join our community and start contributing!
 
-Any changes to utilites in this repo should be send as a PR to this repo.
+Any changes to utilities in this repo should be send as a PR to this repo.
 After the PR is merged, developers should create another PR in the main repo to update the submodule.
 See [this document](https://github.com/kubernetes-client/python/blob/master/devel/submodules.md) for more guidelines.
 
@@ -11,3 +11,19 @@ provides detailed instructions on how to get your ideas and bug fixes seen and a
 
 Please remember to sign the [CNCF CLA](https://github.com/kubernetes/community/blob/master/CLA.md) and
 read and observe the [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+## Adding new Python modules or Python scripts
+If you add a new Python module please make sure it includes the correct header
+as found in:
+```
+hack/boilerplate/boilerplate.py.txt
+```
+
+This module should not include a shebang line.
+
+If you add a new Python helper script intended for developers usage, it should
+go into the directory `hack` and include a shebang line `#!/usr/bin/env python`
+at the top in addition to rest of the boilerplate text as in all other modules.
+
+In addition this script's name should be added to the list   
+`SKIP_FILES`  at the top of hack/boilerplate/boilerplate.py.

--- a/OWNERS
+++ b/OWNERS
@@ -5,4 +5,5 @@ approvers:
   - roycaihw
 emeritus_approvers:
   - mbohlool
-
+reviewers:
+  - fabianvf

--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - mbohlool
   - yliaog
   - roycaihw
+emeritus_approvers:
+  - mbohlool
+

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -15,4 +15,4 @@
 from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
 from .kube_config import (list_kube_config_contexts, load_kube_config,
-                          new_client_from_config, load_kube_config_from_dict)
+                          load_kube_config_from_dict, new_client_from_config)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -12,7 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
-from .kube_config import (list_kube_config_contexts, load_kube_config,
+from .kube_config import (KUBE_CONFIG_DEFAULT_LOCATION,
+                          list_kube_config_contexts, load_kube_config,
                           load_kube_config_from_dict, new_client_from_config)
+
+
+def load_config(**kwargs):
+    """
+    Wrapper function to load the kube_config.
+    It will initially try to load_kube_config from provided path,
+    then check if the KUBE_CONFIG_DEFAULT_LOCATION exists
+    If neither exists, it will fall back to load_incluster_config
+    and inform the user accordingly.
+
+    :param kwargs: A combination of all possible kwargs that
+    can be passed to either load_kube_config or
+    load_incluster_config functions.
+    """
+    if "kube_config_path" in kwargs.keys() or os.path.exists(
+            KUBE_CONFIG_DEFAULT_LOCATION):
+        load_kube_config(**kwargs)
+    else:
+        print(
+            "kube_config_path not provided and "
+            "default location ({0}) does not exist. "
+            "Using inCluster Config. "
+            "This might not work.".format(KUBE_CONFIG_DEFAULT_LOCATION))
+        load_incluster_config(**kwargs)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+from os.path import exists, expanduser
 
 from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
@@ -33,8 +33,7 @@ def load_config(**kwargs):
     can be passed to either load_kube_config or
     load_incluster_config functions.
     """
-    if "kube_config_path" in kwargs.keys() or os.path.exists(
-            KUBE_CONFIG_DEFAULT_LOCATION):
+    if "kube_config_path" in kwargs.keys() or exists(expanduser(KUBE_CONFIG_DEFAULT_LOCATION)):
         load_kube_config(**kwargs)
     else:
         print(

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -15,4 +15,4 @@
 from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
 from .kube_config import (list_kube_config_contexts, load_kube_config,
-                          new_client_from_config)
+                          new_client_from_config, load_kube_config_from_dict)

--- a/config/config_exception.py
+++ b/config/config_exception.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/dateutil.py
+++ b/config/dateutil.py
@@ -46,6 +46,8 @@ _re_rfc3339 = re.compile(r"(\d\d\d\d)-(\d\d)-(\d\d)"        # full-date
                          re.VERBOSE + re.IGNORECASE)
 _re_timezone = re.compile(r"([-+])(\d\d?):?(\d\d)?")
 
+MICROSEC_PER_SEC = 1000000
+
 
 def parse_rfc3339(s):
     if isinstance(s, datetime.datetime):
@@ -57,8 +59,10 @@ def parse_rfc3339(s):
     dt = [0] * 7
     for x in range(6):
         dt[x] = int(groups[x])
+    us = 0
     if groups[6] is not None:
-        dt[6] = int(groups[6])
+        partial_sec = float(groups[6].replace(",", "."))
+        us = int(MICROSEC_PER_SEC * partial_sec)
     tz = UTC
     if groups[7] is not None and groups[7] != 'Z' and groups[7] != 'z':
         tz_groups = _re_timezone.search(groups[7]).groups()
@@ -72,7 +76,7 @@ def parse_rfc3339(s):
     return datetime.datetime(
         year=dt[0], month=dt[1], day=dt[2],
         hour=dt[3], minute=dt[4], second=dt[5],
-        microsecond=dt[6], tzinfo=tz)
+        microsecond=us, tzinfo=tz)
 
 
 def format_rfc3339(date_time):

--- a/config/dateutil.py
+++ b/config/dateutil.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/dateutil_test.py
+++ b/config/dateutil_test.py
@@ -22,24 +22,39 @@ from .dateutil import UTC, TimezoneInfo, format_rfc3339, parse_rfc3339
 
 class DateUtilTest(unittest.TestCase):
 
-    def _parse_rfc3339_test(self, st, y, m, d, h, mn, s):
+    def _parse_rfc3339_test(self, st, y, m, d, h, mn, s, us):
         actual = parse_rfc3339(st)
-        expected = datetime(y, m, d, h, mn, s, 0, UTC)
+        expected = datetime(y, m, d, h, mn, s, us, UTC)
         self.assertEqual(expected, actual)
 
     def test_parse_rfc3339(self):
         self._parse_rfc3339_test("2017-07-25T04:44:21Z",
-                                 2017, 7, 25, 4, 44, 21)
+                                 2017, 7, 25, 4, 44, 21, 0)
         self._parse_rfc3339_test("2017-07-25 04:44:21Z",
-                                 2017, 7, 25, 4, 44, 21)
+                                 2017, 7, 25, 4, 44, 21, 0)
         self._parse_rfc3339_test("2017-07-25T04:44:21",
-                                 2017, 7, 25, 4, 44, 21)
+                                 2017, 7, 25, 4, 44, 21, 0)
         self._parse_rfc3339_test("2017-07-25T04:44:21z",
-                                 2017, 7, 25, 4, 44, 21)
+                                 2017, 7, 25, 4, 44, 21, 0)
         self._parse_rfc3339_test("2017-07-25T04:44:21+03:00",
-                                 2017, 7, 25, 1, 44, 21)
+                                 2017, 7, 25, 1, 44, 21, 0)
         self._parse_rfc3339_test("2017-07-25T04:44:21-03:00",
-                                 2017, 7, 25, 7, 44, 21)
+                                 2017, 7, 25, 7, 44, 21, 0)
+
+        self._parse_rfc3339_test("2017-07-25T04:44:21,005Z",
+                                 2017, 7, 25, 4, 44, 21, 5000)
+        self._parse_rfc3339_test("2017-07-25T04:44:21.005Z",
+                                 2017, 7, 25, 4, 44, 21, 5000)
+        self._parse_rfc3339_test("2017-07-25 04:44:21.0050Z",
+                                 2017, 7, 25, 4, 44, 21, 5000)
+        self._parse_rfc3339_test("2017-07-25T04:44:21.5",
+                                 2017, 7, 25, 4, 44, 21, 500000)
+        self._parse_rfc3339_test("2017-07-25T04:44:21.005z",
+                                 2017, 7, 25, 4, 44, 21, 5000)
+        self._parse_rfc3339_test("2017-07-25T04:44:21.005+03:00",
+                                 2017, 7, 25, 1, 44, 21, 5000)
+        self._parse_rfc3339_test("2017-07-25T04:44:21.005-03:00",
+                                 2017, 7, 25, 7, 44, 21, 5000)
 
     def test_format_rfc3339(self):
         self.assertEqual(

--- a/config/dateutil_test.py
+++ b/config/dateutil_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/exec_provider.py
+++ b/config/exec_provider.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/exec_provider_test.py
+++ b/config/exec_provider_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/incluster_config.py
+++ b/config/incluster_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/incluster_config.py
+++ b/config/incluster_config.py
@@ -70,13 +70,13 @@ class InClusterConfigLoader(object):
                                      self._environ[SERVICE_PORT_ENV_NAME]))
 
         if not os.path.isfile(self._token_filename):
-            raise ConfigException("Service token file does not exists.")
+            raise ConfigException("Service token file does not exist.")
 
         self._read_token_file()
 
         if not os.path.isfile(self._cert_filename):
             raise ConfigException(
-                "Service certification file does not exists.")
+                "Service certification file does not exist.")
 
         with open(self._cert_filename) as f:
             if not f.read():

--- a/config/incluster_config_test.py
+++ b/config/incluster_config_test.py
@@ -142,7 +142,7 @@ class InClusterConfigTest(unittest.TestCase):
 
     def test_no_cert_file(self):
         loader = self.get_test_loader(cert_filename="not_exists_file_1123")
-        self._should_fail_load(loader, "cert file does not exists")
+        self._should_fail_load(loader, "cert file does not exist")
 
     def test_empty_cert_file(self):
         loader = self.get_test_loader(
@@ -151,7 +151,7 @@ class InClusterConfigTest(unittest.TestCase):
 
     def test_no_token_file(self):
         loader = self.get_test_loader(token_filename="not_exists_file_1123")
-        self._should_fail_load(loader, "token file does not exists")
+        self._should_fail_load(loader, "token file does not exist")
 
     def test_empty_token_file(self):
         loader = self.get_test_loader(

--- a/config/incluster_config_test.py
+++ b/config/incluster_config_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -503,7 +503,7 @@ class ConfigNode(object):
 
     def __getitem__(self, key):
         v = self.safe_get(key)
-        if not v:
+        if v is None:
             raise ConfigException(
                 'Invalid kube-config file. Expected key %s in %s'
                 % (key, self.name))

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -688,12 +688,14 @@ class KubeConfigMerger:
             yaml.safe_dump(self.config_files[path], f,
                            default_flow_style=False)
 
+
 def _get_kube_config_loader_for_yaml_file(
         filename, persist_config=False, **kwargs):
     return _get_kube_config_loader(
         filename=filename,
         persist_config=persist_config,
         **kwargs)
+
 
 def _get_kube_config_loader(
         filename=None,
@@ -718,6 +720,7 @@ def _get_kube_config_loader(
             config_dict=config_dict,
             config_base_path=None,
             **kwargs)
+
 
 def list_kube_config_contexts(config_file=None):
 
@@ -757,9 +760,10 @@ def load_kube_config(config_file=None, context=None,
     else:
         loader.load_and_set(client_configuration)
 
+
 def load_kube_config_from_dict(config_dict, context=None,
-                     client_configuration=None,
-                     persist_config=True):
+                               client_configuration=None,
+                               persist_config=True):
     """Loads authentication and cluster information from config_dict file
     and stores them in kubernetes.client.configuration.
 
@@ -787,6 +791,7 @@ def load_kube_config_from_dict(config_dict, context=None,
         Configuration.set_default(config)
     else:
         loader.load_and_set(client_configuration)
+
 
 def new_client_from_config(
         config_file=None,

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -97,6 +97,8 @@ class FileOrData(object):
         self._file = None
         self._data = None
         self._base64_file_content = base64_file_content
+        if not obj:
+            return
         if data_key_name in obj:
             self._data = obj[data_key_name]
         elif file_key_name in obj:

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -326,9 +326,12 @@ class KubeConfigLoader(object):
         )
         refresh_token = config['refresh-token']
         client_id = config['client-id']
-        apiserver_id = config.get(
-            'apiserver-id',
-            '00000002-0000-0000-c000-000000000000')
+        apiserver_id = '00000002-0000-0000-c000-000000000000'
+        try:
+            apiserver_id = config['apiserver-id']
+        except ConfigException:
+            # We've already set a default above
+            pass
         token_response = context.acquire_token_with_refresh_token(
             refresh_token, client_id, apiserver_id)
 

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -336,7 +336,7 @@ class KubeConfigLoader(object):
         provider.value['access-token'] = token_response['accessToken']
         provider.value['expires-on'] = token_response['expiresOn']
         if self._config_persister:
-            self._config_persister(self._config.value)
+            self._config_persister()
 
     def _load_gcp_token(self, provider):
         if (('config' not in provider) or
@@ -357,7 +357,7 @@ class KubeConfigLoader(object):
         provider.value['access-token'] = credentials.token
         provider.value['expiry'] = format_rfc3339(credentials.expiry)
         if self._config_persister:
-            self._config_persister(self._config.value)
+            self._config_persister()
 
     def _load_oid_token(self, provider):
         if 'config' not in provider:
@@ -398,7 +398,7 @@ class KubeConfigLoader(object):
             self._refresh_oidc(provider)
 
             if self._config_persister:
-                self._config_persister(self._config.value)
+                self._config_persister()
 
         self.token = "Bearer %s" % provider['config']['id-token']
 
@@ -691,7 +691,7 @@ def _get_kube_config_loader_for_yaml_file(
 
     kcfg = KubeConfigMerger(filename)
     if persist_config and 'config_persister' not in kwargs:
-        kwargs['config_persister'] = kcfg.save_changes()
+        kwargs['config_persister'] = kcfg.save_changes
 
     if kcfg.config is None:
         raise ConfigException(

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -120,7 +120,7 @@ class FileOrData(object):
             else:
                 self._file = _create_temp_file_with_content(self._data)
         if self._file and not os.path.isfile(self._file):
-            raise ConfigException("File does not exists: %s" % self._file)
+            raise ConfigException("File does not exist: %s" % self._file)
         return self._file
 
     def as_data(self):

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -663,9 +663,8 @@ class KubeConfigMerger:
             for item in ('clusters', 'contexts', 'users'):
                 config_merged[item] = []
             self.config_merged = ConfigNode(path, config_merged, path)
-
         for item in ('clusters', 'contexts', 'users'):
-            self._merge(item, config.get(item, {}), path)
+            self._merge(item, config.get(item, []) or [], path)
         self.config_files[path] = config
 
     def _merge(self, item, add_cfg, path):

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -249,12 +249,15 @@ class KubeConfigLoader(object):
         tenant = config['tenant-id']
         authority = 'https://login.microsoftonline.com/{}'.format(tenant)
         context = adal.AuthenticationContext(
-            authority, validate_authority=True,
+            authority, validate_authority=True, api_version='1.0'
         )
         refresh_token = config['refresh-token']
         client_id = config['client-id']
+        apiserver_id = config.get(
+            'apiserver-id',
+            '00000002-0000-0000-c000-000000000000')
         token_response = context.acquire_token_with_refresh_token(
-            refresh_token, client_id, '00000002-0000-0000-c000-000000000000')
+            refresh_token, client_id, apiserver_id)
 
         provider = self._user['auth-provider']['config']
         provider.value['access-token'] = token_response['accessToken']

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -682,6 +682,9 @@ class KubeConfigMerger:
         else:
             config = yaml.safe_load(string.read())
 
+        if config is None:
+            raise ConfigException(
+                'Invalid kube-config.')
         if self.config_merged is None:
             self.config_merged = copy.deepcopy(config)
         # doesn't need to do any further merging
@@ -698,6 +701,11 @@ class KubeConfigMerger:
     def load_config(self, path):
         with open(path) as f:
             config = yaml.safe_load(f)
+
+        if config is None:
+            raise ConfigException(
+                'Invalid kube-config. '
+                '%s file is empty' % path)
 
         if self.config_merged is None:
             config_merged = copy.deepcopy(config)

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -140,7 +140,11 @@ class KubeConfigLoader(object):
                  config_base_path="",
                  config_persister=None):
 
-        if isinstance(config_dict, ConfigNode):
+        if config_dict is None:
+            raise ConfigException(
+                'Invalid kube-config. '
+                'Expected config_dict to not be None.')
+        elif isinstance(config_dict, ConfigNode):
             self._config = config_dict
         else:
             self._config = ConfigNode('kube-config', config_dict)
@@ -612,6 +616,11 @@ def _get_kube_config_loader_for_yaml_file(
     kcfg = KubeConfigMerger(filename)
     if persist_config and 'config_persister' not in kwargs:
         kwargs['config_persister'] = kcfg.save_changes()
+
+    if kcfg.config is None:
+        raise ConfigException(
+            'Invalid kube-config file. '
+            'No configuration found.')
 
     return KubeConfigLoader(
         config_dict=kcfg.config,

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -474,11 +474,31 @@ class KubeConfigLoader(object):
             return
         try:
             status = ExecProvider(self._user['exec']).run()
-            if 'token' not in status:
-                logging.error('exec: missing token field in plugin output')
-                return None
-            self.token = "Bearer %s" % status['token']
-            return True
+            if 'token' in status:
+                self.token = "Bearer %s" % status['token']
+                return True
+            if 'clientCertificateData' in status:
+                # https://kubernetes.io/docs/reference/access-authn-authz/authentication/#input-and-output-formats
+                # Plugin has provided certificates instead of a token.
+                if 'clientKeyData' not in status:
+                    logging.error('exec: missing clientKeyData field in '
+                                  'plugin output')
+                    return None
+                base_path = self._get_base_path(self._cluster.path)
+                self.cert_file = FileOrData(
+                    status, None,
+                    data_key_name='clientCertificateData',
+                    file_base_path=base_path,
+                    base64_file_content=False).as_file()
+                self.key_file = FileOrData(
+                    status, None,
+                    data_key_name='clientKeyData',
+                    file_base_path=base_path,
+                    base64_file_content=False).as_file()
+                return True
+            logging.error('exec: missing token or clientCertificateData field '
+                          'in plugin output')
+            return None
         except Exception as e:
             logging.error(str(e))
 
@@ -514,12 +534,16 @@ class KubeConfigLoader(object):
                 self.ssl_ca_cert = FileOrData(
                     self._cluster, 'certificate-authority',
                     file_base_path=base_path).as_file()
-                self.cert_file = FileOrData(
-                    self._user, 'client-certificate',
-                    file_base_path=base_path).as_file()
-                self.key_file = FileOrData(
-                    self._user, 'client-key',
-                    file_base_path=base_path).as_file()
+                if 'cert_file' not in self.__dict__:
+                    # cert_file could have been provided by
+                    # _load_from_exec_plugin; only load from the _user
+                    # section if we need it.
+                    self.cert_file = FileOrData(
+                        self._user, 'client-certificate',
+                        file_base_path=base_path).as_file()
+                    self.key_file = FileOrData(
+                        self._user, 'client-key',
+                        file_base_path=base_path).as_file()
         if 'insecure-skip-tls-verify' in self._cluster:
             self.verify_ssl = not self._cluster['insecure-skip-tls-verify']
 

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -155,9 +155,10 @@ class KubeConfigLoader(object):
         self._config_persister = config_persister
 
         def _refresh_credentials():
-            credentials, project_id = google.auth.default(
-                scopes=['https://www.googleapis.com/auth/cloud-platform']
-            )
+            credentials, project_id = google.auth.default(scopes=[
+                'https://www.googleapis.com/auth/cloud-platform',
+                'https://www.googleapis.com/auth/userinfo.email'
+            ])
             request = google.auth.transport.requests.Request()
             credentials.refresh(request)
             return credentials

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -586,7 +586,7 @@ class KubeConfigMerger:
             self.config_merged = ConfigNode(path, config_merged, path)
 
         for item in ('clusters', 'contexts', 'users'):
-            self._merge(item, config[item], path)
+            self._merge(item, config.get(item, {}), path)
         self.config_files[path] = config
 
     def _merge(self, item, add_cfg, path):

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -462,20 +462,6 @@ class TestKubeConfigLoader(BaseTestCase):
                 }
             },
             {
-                "name": "azure_no_apiserver",
-                "context": {
-                    "cluster": "default",
-                    "user": "azure_no_apiserver"
-                }
-            },
-            {
-                "name": "azure_bad_apiserver",
-                "context": {
-                    "cluster": "default",
-                    "user": "azure_bad_apiserver"
-                }
-            },
-            {
                 "name": "expired_oidc",
                 "context": {
                     "cluster": "default",
@@ -765,39 +751,6 @@ class TestKubeConfigLoader(BaseTestCase):
                             "environment": "AzurePublicCloud",
                             "expires-in": "0",
                             "expires-on": "-1",
-                            "refresh-token": "refreshToken",
-                            "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
-                        },
-                        "name": "azure"
-                    }
-                }
-            },
-            {
-                "name": "azure_no_apiserver",
-                "user": {
-                    "auth-provider": {
-                        "config": {
-                            "access-token": TEST_AZURE_TOKEN,
-                            "environment": "AzurePublicCloud",
-                            "expires-in": "0",
-                            "expires-on": "156207275",
-                            "refresh-token": "refreshToken",
-                            "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
-                        },
-                        "name": "azure"
-                    }
-                }
-            },
-            {
-                "name": "azure_bad_apiserver",
-                "user": {
-                    "auth-provider": {
-                        "config": {
-                            "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
-                            "environment": "AzurePublicCloud",
-                            "expires-in": "0",
-                            "expires-on": "156207275",
                             "refresh-token": "refreshToken",
                             "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
                         },
@@ -1161,22 +1114,6 @@ class TestKubeConfigLoader(BaseTestCase):
         )
         provider = loader._user['auth-provider']
         self.assertRaises(ValueError, loader._azure_is_expired, provider)
-
-    def test_azure_with_no_apiserver(self):
-        loader = KubeConfigLoader(
-            config_dict=self.TEST_KUBE_CONFIG,
-            active_context="azure_no_apiserver",
-        )
-        provider = loader._user['auth-provider']
-        self.assertTrue(loader._azure_is_expired(provider))
-
-    def test_azure_with_bad_apiserver(self):
-        loader = KubeConfigLoader(
-            config_dict=self.TEST_KUBE_CONFIG,
-            active_context="azure_bad_apiserver",
-        )
-        provider = loader._user['auth-provider']
-        self.assertTrue(loader._azure_is_expired(provider))
 
     def test_user_pass(self):
         expected = FakeConfig(host=TEST_HOST, token=TEST_BASIC_TOKEN)

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1380,6 +1380,7 @@ class TestKubeConfigLoader(BaseTestCase):
             config_dict=self.TEST_KUBE_CONFIG)
         self.assertIsNone(actual._config_persister)
 
+
 class TestKubernetesClientConfiguration(BaseTestCase):
     # Verifies properties of kubernetes.client.Configuration.
     # These tests guard against changes to the upstream configuration class,

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1290,6 +1290,21 @@ class TestKubeConfigLoader(BaseTestCase):
                                    client_configuration=actual)
         self.assertEqual(expected, actual)
 
+    def test_load_kube_config_from_empty_file_like_object(self):
+        config_file_like_object = io.StringIO()
+        self.assertRaises(
+            ConfigException,
+            load_kube_config,
+            config_file_like_object)
+
+    def test_load_kube_config_from_empty_file(self):
+        config_file = self._create_temp_file(
+            yaml.safe_dump(None))
+        self.assertRaises(
+            ConfigException,
+            load_kube_config,
+            config_file)
+
     def test_list_kube_config_contexts(self):
         config_file = self._create_temp_file(
             yaml.safe_dump(self.TEST_KUBE_CONFIG))

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -564,13 +564,14 @@ class TestKubeConfigLoader(BaseTestCase):
                     "server": TEST_SSL_HOST,
                     "certificate-authority-data":
                         TEST_CERTIFICATE_AUTH_BASE64,
+                    "insecure-skip-tls-verify": False,
                 }
             },
             {
                 "name": "no_ssl_verification",
                 "cluster": {
                     "server": TEST_SSL_HOST,
-                    "insecure-skip-tls-verify": "true",
+                    "insecure-skip-tls-verify": True,
                 }
             },
         ],
@@ -1076,7 +1077,8 @@ class TestKubeConfigLoader(BaseTestCase):
             token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
             cert_file=self._create_temp_file(TEST_CLIENT_CERT),
             key_file=self._create_temp_file(TEST_CLIENT_KEY),
-            ssl_ca_cert=self._create_temp_file(TEST_CERTIFICATE_AUTH)
+            ssl_ca_cert=self._create_temp_file(TEST_CERTIFICATE_AUTH),
+            verify_ssl=True
         )
         actual = FakeConfig()
         KubeConfigLoader(

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -33,9 +33,10 @@ from .kube_config import (ENV_KUBECONFIG_PATH_SEPARATOR, CommandTokenSource,
                           ConfigNode, FileOrData, KubeConfigLoader,
                           KubeConfigMerger, _cleanup_temp_files,
                           _create_temp_file_with_content,
+                          _get_kube_config_loader,
                           _get_kube_config_loader_for_yaml_file,
                           list_kube_config_contexts, load_kube_config,
-                          new_client_from_config)
+                          load_kube_config_from_dict, new_client_from_config)
 
 BEARER_TOKEN_FORMAT = "Bearer %s"
 
@@ -1229,6 +1230,16 @@ class TestKubeConfigLoader(BaseTestCase):
                          client_configuration=actual)
         self.assertEqual(expected, actual)
 
+    def test_load_kube_config_from_dict(self):
+        expected = FakeConfig(host=TEST_HOST,
+                              token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64)
+
+        actual = FakeConfig()
+        load_kube_config_from_dict(config_dict=self.TEST_KUBE_CONFIG,
+                                   context="simple_token",
+                                   client_configuration=actual)
+        self.assertEqual(expected, actual)
+
     def test_list_kube_config_contexts(self):
         config_file = self._create_temp_file(
             yaml.safe_dump(self.TEST_KUBE_CONFIG))
@@ -1344,6 +1355,30 @@ class TestKubeConfigLoader(BaseTestCase):
         self.assertTrue(callable(actual._config_persister))
         self.assertEquals(actual._config_persister.__name__, "save_changes")
 
+    def test__get_kube_config_loader_file_no_persist(self):
+        expected = FakeConfig(host=TEST_HOST,
+                              token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64)
+        config_file = self._create_temp_file(
+            yaml.safe_dump(self.TEST_KUBE_CONFIG))
+        actual = _get_kube_config_loader(filename=config_file)
+        self.assertIsNone(actual._config_persister)
+
+    def test__get_kube_config_loader_file_persist(self):
+        expected = FakeConfig(host=TEST_HOST,
+                              token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64)
+        config_file = self._create_temp_file(
+            yaml.safe_dump(self.TEST_KUBE_CONFIG))
+        actual = _get_kube_config_loader(filename=config_file,
+                                         persist_config=True)
+        self.assertTrue(callable(actual._config_persister))
+        self.assertEquals(actual._config_persister.__name__, "save_changes")
+
+    def test__get_kube_config_loader_dict_no_persist(self):
+        expected = FakeConfig(host=TEST_HOST,
+                              token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64)
+        actual = _get_kube_config_loader(
+            config_dict=self.TEST_KUBE_CONFIG)
+        self.assertIsNone(actual._config_persister)
 
 class TestKubernetesClientConfiguration(BaseTestCase):
     # Verifies properties of kubernetes.client.Configuration.

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1290,6 +1290,29 @@ class TestKubeConfigLoader(BaseTestCase):
                                    client_configuration=actual)
         self.assertEqual(expected, actual)
 
+    def test_load_kube_config_from_dict_with_temp_file_path(self):
+        expected = FakeConfig(
+            host=TEST_SSL_HOST,
+            token=BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
+            cert_file=self._create_temp_file(TEST_CLIENT_CERT),
+            key_file=self._create_temp_file(TEST_CLIENT_KEY),
+            ssl_ca_cert=self._create_temp_file(TEST_CERTIFICATE_AUTH),
+            verify_ssl=True
+        )
+        actual = FakeConfig()
+        tmp_path = os.path.join(
+            os.path.dirname(
+                os.path.dirname(
+                    os.path.abspath(__file__))),
+            'tmp_file_path_test')
+        load_kube_config_from_dict(config_dict=self.TEST_KUBE_CONFIG,
+                                   context="ssl",
+                                   client_configuration=actual,
+                                   temp_file_path=tmp_path)
+        self.assertFalse(True if not os.listdir(tmp_path) else False)
+        self.assertEqual(expected, actual)
+        _cleanup_temp_files
+
     def test_load_kube_config_from_empty_file_like_object(self):
         config_file_like_object = io.StringIO()
         self.assertRaises(

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1353,7 +1353,7 @@ class TestKubeConfigLoader(BaseTestCase):
         actual = _get_kube_config_loader_for_yaml_file(config_file,
                                                        persist_config=True)
         self.assertTrue(callable(actual._config_persister))
-        self.assertEquals(actual._config_persister.__name__, "save_changes")
+        self.assertEqual(actual._config_persister.__name__, "save_changes")
 
     def test__get_kube_config_loader_file_no_persist(self):
         expected = FakeConfig(host=TEST_HOST,
@@ -1553,6 +1553,26 @@ class TestKubeConfigMerger(BaseTestCase):
             }
         ]
     }
+    TEST_KUBE_CONFIG_PART6 = {
+        "current-context": "no_user",
+        "contexts": [
+            {
+                "name": "no_user",
+                "context": {
+                    "cluster": "default"
+                }
+            },
+        ],
+        "clusters": [
+            {
+                "name": "default",
+                "cluster": {
+                    "server": TEST_HOST
+                }
+            },
+        ],
+        "users": None
+    }
 
     def _create_multi_config(self):
         files = []
@@ -1561,7 +1581,8 @@ class TestKubeConfigMerger(BaseTestCase):
                 self.TEST_KUBE_CONFIG_PART2,
                 self.TEST_KUBE_CONFIG_PART3,
                 self.TEST_KUBE_CONFIG_PART4,
-                self.TEST_KUBE_CONFIG_PART5):
+                self.TEST_KUBE_CONFIG_PART5,
+                self.TEST_KUBE_CONFIG_PART6):
             files.append(self._create_temp_file(yaml.safe_dump(part)))
         return ENV_KUBECONFIG_PATH_SEPARATOR.join(files)
 

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -178,7 +178,7 @@ class TestFileOrData(BaseTestCase):
         temp_filename = NON_EXISTING_FILE
         obj = {TEST_FILE_KEY: temp_filename}
         t = FileOrData(obj=obj, file_key_name=TEST_FILE_KEY)
-        self.expect_exception(t.as_file, "does not exists")
+        self.expect_exception(t.as_file, "does not exist")
 
     def test_file_given_data(self):
         obj = {TEST_DATA_KEY: TEST_DATA_BASE64}
@@ -1165,7 +1165,7 @@ class TestKubeConfigLoader(BaseTestCase):
             active_context="ssl-no_file")
         self.expect_exception(
             loader.load_and_set,
-            "does not exists",
+            "does not exist",
             FakeConfig())
 
     def test_ssl(self):

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -255,6 +255,16 @@ class TestFileOrData(BaseTestCase):
                        data_key_name=TEST_DATA_KEY, base64_file_content=False)
         self.assertEqual(TEST_DATA, self.get_file_content(t.as_file()))
 
+    def test_file_given_no_object(self):
+        t = FileOrData(obj=None, file_key_name=TEST_FILE_KEY,
+                       data_key_name=TEST_DATA_KEY)
+        self.assertEqual(t.as_file(), None)
+
+    def test_file_given_no_object_data(self):
+        t = FileOrData(obj=None, file_key_name=TEST_FILE_KEY,
+                       data_key_name=TEST_DATA_KEY)
+        self.assertEqual(t.as_data(), None)
+
 
 class TestConfigNode(BaseTestCase):
 

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -458,6 +458,20 @@ class TestKubeConfigLoader(BaseTestCase):
                 }
             },
             {
+                "name": "azure_no_apiserver",
+                "context": {
+                    "cluster": "default",
+                    "user": "azure_no_apiserver"
+                }
+            },
+            {
+                "name": "azure_bad_apiserver",
+                "context": {
+                    "cluster": "default",
+                    "user": "azure_bad_apiserver"
+                }
+            },
+            {
                 "name": "expired_oidc",
                 "context": {
                     "cluster": "default",
@@ -647,7 +661,7 @@ class TestKubeConfigLoader(BaseTestCase):
                     "auth-provider": {
                         "config": {
                             "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
+                            "apiserver-id": "00000002-0000-0000-c000-000000000000",
                             "environment": "AzurePublicCloud",
                             "refresh-token": "refreshToken",
                             "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
@@ -662,7 +676,7 @@ class TestKubeConfigLoader(BaseTestCase):
                     "auth-provider": {
                         "config": {
                             "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
+                            "apiserver-id": "00000002-0000-0000-c000-000000000000",
                             "environment": "AzurePublicCloud",
                             "expires-in": "0",
                             "expires-on": "156207275",
@@ -679,7 +693,7 @@ class TestKubeConfigLoader(BaseTestCase):
                     "auth-provider": {
                         "config": {
                             "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
+                            "apiserver-id": "00000002-0000-0000-c000-000000000000",
                             "environment": "AzurePublicCloud",
                             "expires-in": "0",
                             "expires-on": "2018-10-18 00:52:29.044727",
@@ -696,7 +710,7 @@ class TestKubeConfigLoader(BaseTestCase):
                     "auth-provider": {
                         "config": {
                             "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
+                            "apiserver-id": "00000002-0000-0000-c000-000000000000",
                             "environment": "AzurePublicCloud",
                             "expires-in": "0",
                             "expires-on": "2018-10-18 00:52",
@@ -713,10 +727,43 @@ class TestKubeConfigLoader(BaseTestCase):
                     "auth-provider": {
                         "config": {
                             "access-token": TEST_AZURE_TOKEN,
-                            "apiserver-id": "ApiserverId",
+                            "apiserver-id": "00000002-0000-0000-c000-000000000000",
                             "environment": "AzurePublicCloud",
                             "expires-in": "0",
                             "expires-on": "-1",
+                            "refresh-token": "refreshToken",
+                            "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
+                        },
+                        "name": "azure"
+                    }
+                }
+            },
+            {
+                "name": "azure_no_apiserver",
+                "user": {
+                    "auth-provider": {
+                        "config": {
+                            "access-token": TEST_AZURE_TOKEN,
+                            "environment": "AzurePublicCloud",
+                            "expires-in": "0",
+                            "expires-on": "156207275",
+                            "refresh-token": "refreshToken",
+                            "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
+                        },
+                        "name": "azure"
+                    }
+                }
+            },
+            {
+                "name": "azure_bad_apiserver",
+                "user": {
+                    "auth-provider": {
+                        "config": {
+                            "access-token": TEST_AZURE_TOKEN,
+                            "apiserver-id": "ApiserverId",
+                            "environment": "AzurePublicCloud",
+                            "expires-in": "0",
+                            "expires-on": "156207275",
                             "refresh-token": "refreshToken",
                             "tenant-id": "9d2ac018-e843-4e14-9e2b-4e0ddac75433"
                         },
@@ -1046,6 +1093,22 @@ class TestKubeConfigLoader(BaseTestCase):
         )
         provider = loader._user['auth-provider']
         self.assertRaises(ValueError, loader._azure_is_expired, provider)
+
+    def test_azure_with_no_apiserver(self):
+        loader = KubeConfigLoader(
+            config_dict=self.TEST_KUBE_CONFIG,
+            active_context="azure_no_apiserver",
+        )
+        provider = loader._user['auth-provider']
+        self.assertTrue(loader._azure_is_expired(provider))
+
+    def test_azure_with_bad_apiserver(self):
+        loader = KubeConfigLoader(
+            config_dict=self.TEST_KUBE_CONFIG,
+            active_context="azure_bad_apiserver",
+        )
+        provider = loader._user['auth-provider']
+        self.assertTrue(loader._azure_is_expired(provider))
 
     def test_user_pass(self):
         expected = FakeConfig(host=TEST_HOST, token=TEST_BASIC_TOKEN)

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1355,13 +1355,17 @@ class TestKubeConfigMerger(BaseTestCase):
             },
         ]
     }
+    TEST_KUBE_CONFIG_PART4 = {
+        "current-context": "no_user",
+    }
 
     def _create_multi_config(self):
         files = []
         for part in (
                 self.TEST_KUBE_CONFIG_PART1,
                 self.TEST_KUBE_CONFIG_PART2,
-                self.TEST_KUBE_CONFIG_PART3):
+                self.TEST_KUBE_CONFIG_PART3,
+                self.TEST_KUBE_CONFIG_PART4):
             files.append(self._create_temp_file(yaml.safe_dump(part)))
         return ENV_KUBECONFIG_PATH_SEPARATOR.join(files)
 

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1399,11 +1399,13 @@ class TestKubernetesClientConfiguration(BaseTestCase):
 
     def test_auth_settings_calls_get_api_key_with_prefix(self):
         expected_token = 'expected_token'
+        old_token = 'old_token'
 
         def fake_get_api_key_with_prefix(identifier):
             self.assertEqual('authorization', identifier)
             return expected_token
         config = Configuration()
+        config.api_key['authorization'] = old_token
         config.get_api_key_with_prefix = fake_get_api_key_with_prefix
         self.assertEqual(expected_token,
                          config.auth_settings()['BearerToken']['value'])

--- a/dynamic/__init__.py
+++ b/dynamic/__init__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .client import *  # NOQA

--- a/dynamic/__init__.py
+++ b/dynamic/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/client.py
+++ b/dynamic/client.py
@@ -98,7 +98,12 @@ class DynamicClient(object):
         return namespace
 
     def serialize_body(self, body):
-        if hasattr(body, 'to_dict'):
+        """Serialize body to raw dict so apiserver can handle it
+
+        :param body: kubernetes resource body, current support: Union[Dict, ResourceInstance]
+        """
+        # This should match any `ResourceInstance` instances
+        if callable(getattr(body, 'to_dict', None)):
             return body.to_dict()
         return body or {}
 

--- a/dynamic/client.py
+++ b/dynamic/client.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+import json
+
+from kubernetes import watch
+from kubernetes.client.rest import ApiException
+
+from .discovery import EagerDiscoverer, LazyDiscoverer
+from .exceptions import api_exception, KubernetesValidateMissing
+from .resource import Resource, ResourceList, Subresource, ResourceInstance, ResourceField
+
+try:
+    import kubernetes_validate
+    HAS_KUBERNETES_VALIDATE = True
+except ImportError:
+    HAS_KUBERNETES_VALIDATE = False
+
+try:
+    from kubernetes_validate.utils import VersionNotSupportedError
+except ImportError:
+    class VersionNotSupportedError(NotImplementedError):
+        pass
+
+__all__ = [
+    'DynamicClient',
+    'ResourceInstance',
+    'Resource',
+    'ResourceList',
+    'Subresource',
+    'EagerDiscoverer',
+    'LazyDiscoverer',
+    'ResourceField',
+]
+
+
+def meta_request(func):
+    """ Handles parsing response structure and translating API Exceptions """
+    def inner(self, *args, **kwargs):
+        serialize_response = kwargs.pop('serialize', True)
+        serializer = kwargs.pop('serializer', ResourceInstance)
+        try:
+            resp = func(self, *args, **kwargs)
+        except ApiException as e:
+            raise api_exception(e)
+        if serialize_response:
+            try:
+                if six.PY2:
+                    return serializer(self, json.loads(resp.data))
+                return serializer(self, json.loads(resp.data.decode('utf8')))
+            except ValueError:
+                if six.PY2:
+                    return resp.data
+                return resp.data.decode('utf8')
+        return resp
+
+    return inner
+
+
+class DynamicClient(object):
+    """ A kubernetes client that dynamically discovers and interacts with
+        the kubernetes API
+    """
+
+    def __init__(self, client, cache_file=None, discoverer=None):
+        # Setting default here to delay evaluation of LazyDiscoverer class
+        # until constructor is called
+        discoverer = discoverer or LazyDiscoverer
+
+        self.client = client
+        self.configuration = client.configuration
+        self.__discoverer = discoverer(self, cache_file)
+
+    @property
+    def resources(self):
+        return self.__discoverer
+
+    @property
+    def version(self):
+        return self.__discoverer.version
+
+    def ensure_namespace(self, resource, namespace, body):
+        namespace = namespace or body.get('metadata', {}).get('namespace')
+        if not namespace:
+            raise ValueError("Namespace is required for {}.{}".format(resource.group_version, resource.kind))
+        return namespace
+
+    def serialize_body(self, body):
+        if hasattr(body, 'to_dict'):
+            return body.to_dict()
+        return body or {}
+
+    def get(self, resource, name=None, namespace=None, **kwargs):
+        path = resource.path(name=name, namespace=namespace)
+        return self.request('get', path, **kwargs)
+
+    def create(self, resource, body=None, namespace=None, **kwargs):
+        body = self.serialize_body(body)
+        if resource.namespaced:
+            namespace = self.ensure_namespace(resource, namespace, body)
+        path = resource.path(namespace=namespace)
+        return self.request('post', path, body=body, **kwargs)
+
+    def delete(self, resource, name=None, namespace=None, body=None, label_selector=None, field_selector=None, **kwargs):
+        if not (name or label_selector or field_selector):
+            raise ValueError("At least one of name|label_selector|field_selector is required")
+        if resource.namespaced and not (label_selector or field_selector or namespace):
+            raise ValueError("At least one of namespace|label_selector|field_selector is required")
+        path = resource.path(name=name, namespace=namespace)
+        return self.request('delete', path, body=body, label_selector=label_selector, field_selector=field_selector, **kwargs)
+
+    def replace(self, resource, body=None, name=None, namespace=None, **kwargs):
+        body = self.serialize_body(body)
+        name = name or body.get('metadata', {}).get('name')
+        if not name:
+            raise ValueError("name is required to replace {}.{}".format(resource.group_version, resource.kind))
+        if resource.namespaced:
+            namespace = self.ensure_namespace(resource, namespace, body)
+        path = resource.path(name=name, namespace=namespace)
+        return self.request('put', path, body=body, **kwargs)
+
+    def patch(self, resource, body=None, name=None, namespace=None, **kwargs):
+        body = self.serialize_body(body)
+        name = name or body.get('metadata', {}).get('name')
+        if not name:
+            raise ValueError("name is required to patch {}.{}".format(resource.group_version, resource.kind))
+        if resource.namespaced:
+            namespace = self.ensure_namespace(resource, namespace, body)
+
+        content_type = kwargs.pop('content_type', 'application/strategic-merge-patch+json')
+        path = resource.path(name=name, namespace=namespace)
+
+        return self.request('patch', path, body=body, content_type=content_type, **kwargs)
+
+    def watch(self, resource, namespace=None, name=None, label_selector=None, field_selector=None, resource_version=None, timeout=None):
+        """
+        Stream events for a resource from the Kubernetes API
+
+        :param resource: The API resource object that will be used to query the API
+        :param namespace: The namespace to query
+        :param name: The name of the resource instance to query
+        :param label_selector: The label selector with which to filter results
+        :param field_selector: The field selector with which to filter results
+        :param resource_version: The version with which to filter results. Only events with
+                                 a resource_version greater than this value will be returned
+        :param timeout: The amount of time in seconds to wait before terminating the stream
+
+        :return: Event object with these keys:
+                   'type': The type of event such as "ADDED", "DELETED", etc.
+                   'raw_object': a dict representing the watched object.
+                   'object': A ResourceInstance wrapping raw_object.
+
+        Example:
+            client = DynamicClient(k8s_client)
+            v1_pods = client.resources.get(api_version='v1', kind='Pod')
+
+            for e in v1_pods.watch(resource_version=0, namespace=default, timeout=5):
+                print(e['type'])
+                print(e['object'].metadata)
+        """
+        watcher = watch.Watch()
+        for event in watcher.stream(
+            resource.get,
+            namespace=namespace,
+            name=name,
+            field_selector=field_selector,
+            label_selector=label_selector,
+            resource_version=resource_version,
+            serialize=False,
+            timeout_seconds=timeout
+        ):
+            event['object'] = ResourceInstance(resource, event['object'])
+            yield event
+
+    @meta_request
+    def request(self, method, path, body=None, **params):
+        if not path.startswith('/'):
+            path = '/' + path
+
+        path_params = params.get('path_params', {})
+        query_params = params.get('query_params', [])
+        if params.get('pretty') is not None:
+            query_params.append(('pretty', params['pretty']))
+        if params.get('_continue') is not None:
+            query_params.append(('continue', params['_continue']))
+        if params.get('include_uninitialized') is not None:
+            query_params.append(('includeUninitialized', params['include_uninitialized']))
+        if params.get('field_selector') is not None:
+            query_params.append(('fieldSelector', params['field_selector']))
+        if params.get('label_selector') is not None:
+            query_params.append(('labelSelector', params['label_selector']))
+        if params.get('limit') is not None:
+            query_params.append(('limit', params['limit']))
+        if params.get('resource_version') is not None:
+            query_params.append(('resourceVersion', params['resource_version']))
+        if params.get('timeout_seconds') is not None:
+            query_params.append(('timeoutSeconds', params['timeout_seconds']))
+        if params.get('watch') is not None:
+            query_params.append(('watch', params['watch']))
+        if params.get('grace_period_seconds') is not None:
+            query_params.append(('gracePeriodSeconds', params['grace_period_seconds']))
+        if params.get('propagation_policy') is not None:
+            query_params.append(('propagationPolicy', params['propagation_policy']))
+        if params.get('orphan_dependents') is not None:
+            query_params.append(('orphanDependents', params['orphan_dependents']))
+
+        header_params = params.get('header_params', {})
+        form_params = []
+        local_var_files = {}
+        # HTTP header `Accept`
+        header_params['Accept'] = self.client.select_header_accept([
+            'application/json',
+            'application/yaml',
+        ])
+
+        # HTTP header `Content-Type`
+        if params.get('content_type'):
+            header_params['Content-Type'] = params['content_type']
+        else:
+            header_params['Content-Type'] = self.client.select_header_content_type(['*/*'])
+
+        # Authentication setting
+        auth_settings = ['BearerToken']
+
+        return self.client.call_api(
+            path,
+            method.upper(),
+            path_params,
+            query_params,
+            header_params,
+            body=body,
+            post_params=form_params,
+            async_req=params.get('async_req'),
+            files=local_var_files,
+            auth_settings=auth_settings,
+            _preload_content=False,
+            _return_http_data_only=params.get('_return_http_data_only', True)
+        )
+
+    def validate(self, definition, version=None, strict=False):
+        """validate checks a kubernetes resource definition
+
+        Args:
+            definition (dict): resource definition
+            version (str): version of kubernetes to validate against
+            strict (bool): whether unexpected additional properties should be considered errors
+
+        Returns:
+            warnings (list), errors (list): warnings are missing validations, errors are validation failures
+        """
+        if not HAS_KUBERNETES_VALIDATE:
+            raise KubernetesValidateMissing()
+
+        errors = list()
+        warnings = list()
+        try:
+            if version is None:
+                try:
+                    version = self.version['kubernetes']['gitVersion']
+                except KeyError:
+                    version = kubernetes_validate.latest_version()
+            kubernetes_validate.validate(definition, version, strict)
+        except kubernetes_validate.utils.ValidationError as e:
+            errors.append("resource definition validation error at %s: %s" % ('.'.join([str(item) for item in e.path]), e.message))  # noqa: B306
+        except VersionNotSupportedError:
+            errors.append("Kubernetes version %s is not supported by kubernetes-validate" % version)
+        except kubernetes_validate.utils.SchemaNotFoundError as e:
+            warnings.append("Could not find schema for object kind %s with API version %s in Kubernetes version %s (possibly Custom Resource?)" %
+                            (e.kind, e.api_version, e.version))
+        return warnings, errors

--- a/dynamic/client.py
+++ b/dynamic/client.py
@@ -220,6 +220,8 @@ class DynamicClient(object):
             query_params.append(('propagationPolicy', params['propagation_policy']))
         if params.get('orphan_dependents') is not None:
             query_params.append(('orphanDependents', params['orphan_dependents']))
+        if params.get('dry_run') is not None:
+            query_params.append(('dryRun', params['dry_run']))
 
         header_params = params.get('header_params', {})
         form_params = []

--- a/dynamic/client.py
+++ b/dynamic/client.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/client.py
+++ b/dynamic/client.py
@@ -219,11 +219,14 @@ class DynamicClient(object):
         header_params = params.get('header_params', {})
         form_params = []
         local_var_files = {}
-        # HTTP header `Accept`
-        header_params['Accept'] = self.client.select_header_accept([
-            'application/json',
-            'application/yaml',
-        ])
+
+        # Checking Accept header.
+        new_header_params = dict((key.lower(), value) for key, value in header_params.items())
+        if not 'accept' in new_header_params:
+            header_params['Accept'] = self.client.select_header_accept([
+                'application/json',
+                'application/yaml',
+            ])
 
         # HTTP header `Content-Type`
         if params.get('content_type'):

--- a/dynamic/discovery.py
+++ b/dynamic/discovery.py
@@ -254,8 +254,11 @@ class LazyDiscoverer(Discoverer):
                 # Check if we've requested resources for this group
                 if not resourcePart.resources:
                     prefix, group, version = reqParams[0], reqParams[1], part
-                    resourcePart.resources = self.get_resources_for_api_version(
-                        prefix, group, part, resourcePart.preferred)
+                    try:
+                        resourcePart.resources = self.get_resources_for_api_version(
+                            prefix, group, part, resourcePart.preferred)
+                    except NotFoundError:
+                        raise ResourceNotFoundError
 
                     self._cache['resources'][prefix][group][version] = resourcePart
                     self.__update_cache = True

--- a/dynamic/discovery.py
+++ b/dynamic/discovery.py
@@ -15,8 +15,10 @@
 import os
 import six
 import json
+import logging
 import hashlib
 import tempfile
+from functools import partial
 from collections import defaultdict
 from abc import abstractmethod, abstractproperty
 
@@ -54,11 +56,12 @@ class Discoverer(object):
         else:
             try:
                 with open(self.__cache_file, 'r') as f:
-                    self._cache = json.load(f, cls=CacheDecoder(self.client))
+                    self._cache = json.load(f, cls=partial(CacheDecoder, self.client))
                 if self._cache.get('library_version') != __version__:
                     # Version mismatch, need to refresh cache
                     self.invalidate_cache()
-            except Exception:
+            except Exception as e:
+                logging.error("load cache error: %s", e)
                 self.invalidate_cache()
         self._load_server_info()
         self.discover()

--- a/dynamic/discovery.py
+++ b/dynamic/discovery.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/discovery.py
+++ b/dynamic/discovery.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import six
+import json
+import hashlib
+import tempfile
+from collections import defaultdict
+from abc import abstractmethod, abstractproperty
+
+from urllib3.exceptions import ProtocolError, MaxRetryError
+
+from kubernetes import __version__
+from .exceptions import NotFoundError, ResourceNotFoundError, ResourceNotUniqueError, ApiException
+from .resource import Resource, ResourceList
+
+
+DISCOVERY_PREFIX = 'apis'
+
+
+class Discoverer(object):
+    """
+        A convenient container for storing discovered API resources. Allows
+        easy searching and retrieval of specific resources.
+
+        Subclasses implement the abstract methods with different loading strategies.
+    """
+
+    def __init__(self, client, cache_file):
+        self.client = client
+        default_cache_id = self.client.configuration.host
+        if six.PY3:
+            default_cache_id = default_cache_id.encode('utf-8')
+        default_cachefile_name = 'osrcp-{0}.json'.format(hashlib.md5(default_cache_id).hexdigest())
+        self.__cache_file = cache_file or os.path.join(tempfile.gettempdir(), default_cachefile_name)
+        self.__init_cache()
+
+    def __init_cache(self, refresh=False):
+        if refresh or not os.path.exists(self.__cache_file):
+            self._cache = {'library_version': __version__}
+            refresh = True
+        else:
+            try:
+                with open(self.__cache_file, 'r') as f:
+                    self._cache = json.load(f, cls=CacheDecoder(self.client))
+                if self._cache.get('library_version') != __version__:
+                    # Version mismatch, need to refresh cache
+                    self.invalidate_cache()
+            except Exception:
+                self.invalidate_cache()
+        self._load_server_info()
+        self.discover()
+        if refresh:
+            self._write_cache()
+
+    def _write_cache(self):
+        try:
+            with open(self.__cache_file, 'w') as f:
+                json.dump(self._cache, f, cls=CacheEncoder)
+        except Exception:
+            # Failing to write the cache isn't a big enough error to crash on
+            pass
+
+    def invalidate_cache(self):
+        self.__init_cache(refresh=True)
+
+    @abstractproperty
+    def api_groups(self):
+        pass
+
+    @abstractmethod
+    def search(self, prefix=None, group=None, api_version=None, kind=None, **kwargs):
+        pass
+
+    @abstractmethod
+    def discover(self):
+        pass
+
+    @property
+    def version(self):
+        return self.__version
+
+    def default_groups(self, request_resources=False):
+        groups = {}
+        groups['api'] = { '': {
+            'v1': (ResourceGroup( True, resources=self.get_resources_for_api_version('api', '', 'v1', True) )
+                if request_resources else ResourceGroup(True))
+        }}
+
+        groups[DISCOVERY_PREFIX] = {'': {
+            'v1': ResourceGroup(True, resources = {"List": [ResourceList(self.client)]})
+        }}
+        return groups
+
+    def parse_api_groups(self, request_resources=False, update=False):
+        """ Discovers all API groups present in the cluster """
+        if not self._cache.get('resources') or update:
+            self._cache['resources'] = self._cache.get('resources', {})
+            groups_response = self.client.request('GET', '/{}'.format(DISCOVERY_PREFIX)).groups
+
+            groups = self.default_groups(request_resources=request_resources)
+
+            for group in groups_response:
+                new_group = {}
+                for version_raw in group['versions']:
+                    version = version_raw['version']
+                    resource_group = self._cache.get('resources', {}).get(DISCOVERY_PREFIX, {}).get(group['name'], {}).get(version)
+                    preferred = version_raw == group['preferredVersion']
+                    resources = resource_group.resources if resource_group else {}
+                    if request_resources:
+                        resources = self.get_resources_for_api_version(DISCOVERY_PREFIX, group['name'], version, preferred)
+                    new_group[version] = ResourceGroup(preferred, resources=resources)
+                groups[DISCOVERY_PREFIX][group['name']] = new_group
+            self._cache['resources'].update(groups)
+            self._write_cache()
+
+        return self._cache['resources']
+
+    def _load_server_info(self):
+        def just_json(_, serialized):
+            return serialized
+
+        if not self._cache.get('version'):
+            try:
+                self._cache['version'] = {
+                    'kubernetes': self.client.request('get', '/version', serializer=just_json)
+                }
+            except (ValueError, MaxRetryError) as e:
+                if isinstance(e, MaxRetryError) and not isinstance(e.reason, ProtocolError):
+                    raise
+                if not self.client.configuration.host.startswith("https://"):
+                    raise ValueError("Host value %s should start with https:// when talking to HTTPS endpoint" %
+                                     self.client.configuration.host)
+                else:
+                    raise
+
+        self.__version = self._cache['version']
+
+    def get_resources_for_api_version(self, prefix, group, version, preferred):
+        """ returns a dictionary of resources associated with provided (prefix, group, version)"""
+
+        resources = defaultdict(list)
+        subresources = {}
+
+        path = '/'.join(filter(None, [prefix, group, version]))
+        resources_response = self.client.request('GET', path).resources or []
+
+        resources_raw = list(filter(lambda resource: '/' not in resource['name'], resources_response))
+        subresources_raw = list(filter(lambda resource: '/' in resource['name'], resources_response))
+        for subresource in subresources_raw:
+            resource, name = subresource['name'].split('/')
+            if not subresources.get(resource):
+                subresources[resource] = {}
+            subresources[resource][name] = subresource
+
+        for resource in resources_raw:
+            # Prevent duplicate keys
+            for key in ('prefix', 'group', 'api_version', 'client', 'preferred'):
+                resource.pop(key, None)
+
+            resourceobj = Resource(
+                prefix=prefix,
+                group=group,
+                api_version=version,
+                client=self.client,
+                preferred=preferred,
+                subresources=subresources.get(resource['name']),
+                **resource
+            )
+            resources[resource['kind']].append(resourceobj)
+
+            resource_list = ResourceList(self.client, group=group, api_version=version, base_kind=resource['kind'])
+            resources[resource_list.kind].append(resource_list)
+        return resources
+
+    def get(self, **kwargs):
+        """ Same as search, but will throw an error if there are multiple or no
+            results. If there are multiple results and only one is an exact match
+            on api_version, that resource will be returned.
+        """
+        results = self.search(**kwargs)
+        # If there are multiple matches, prefer exact matches on api_version
+        if len(results) > 1 and kwargs.get('api_version'):
+            results = [
+                result for result in results if result.group_version == kwargs['api_version']
+            ]
+        # If there are multiple matches, prefer non-List kinds
+        if len(results) > 1 and not all([isinstance(x, ResourceList) for x in results]):
+            results = [result for result in results if not isinstance(result, ResourceList)]
+        if len(results) == 1:
+            return results[0]
+        elif not results:
+            raise ResourceNotFoundError('No matches found for {}'.format(kwargs))
+        else:
+            raise ResourceNotUniqueError('Multiple matches found for {}: {}'.format(kwargs, results))
+
+
+class LazyDiscoverer(Discoverer):
+    """ A convenient container for storing discovered API resources. Allows
+        easy searching and retrieval of specific resources.
+
+        Resources for the cluster are loaded lazily.
+    """
+
+    def __init__(self, client, cache_file):
+        Discoverer.__init__(self, client, cache_file)
+        self.__update_cache = False
+
+    def discover(self):
+        self.__resources = self.parse_api_groups(request_resources=False)
+
+    def __maybe_write_cache(self):
+        if self.__update_cache:
+            self._write_cache()
+            self.__update_cache = False
+
+    @property
+    def api_groups(self):
+        return self.parse_api_groups(request_resources=False, update=True)['apis'].keys()
+
+    def search(self, **kwargs):
+        results = self.__search(self.__build_search(**kwargs), self.__resources, [])
+        if not results:
+            self.invalidate_cache()
+            results = self.__search(self.__build_search(**kwargs), self.__resources, [])
+        self.__maybe_write_cache()
+        return results
+
+    def __search(self,  parts, resources, reqParams):
+        part = parts[0]
+        if part != '*':
+
+            resourcePart = resources.get(part)
+            if not resourcePart:
+                return []
+            elif isinstance(resourcePart, ResourceGroup):
+                if len(reqParams) != 2:
+                    raise ValueError("prefix and group params should be present, have %s" % reqParams)
+                # Check if we've requested resources for this group
+                if not resourcePart.resources:
+                    prefix, group, version = reqParams[0], reqParams[1], part
+                    try:
+                        resourcePart.resources = self.get_resources_for_api_version(prefix,
+                            group, part, resourcePart.preferred)
+                    except NotFoundError:
+                        raise ResourceNotFoundError
+                    self._cache['resources'][prefix][group][version] = resourcePart
+                    self.__update_cache=True
+                return self.__search(parts[1:], resourcePart.resources, reqParams)
+            elif isinstance(resourcePart, dict):
+                # In this case parts [0] will be a specified prefix, group, version
+                # as we recurse
+                return self.__search(parts[1:], resourcePart, reqParams + [part] )
+            else:
+                if parts[1] != '*' and isinstance(parts[1], dict):
+                    for _resource in resourcePart:
+                        for term, value in parts[1].items():
+                            if getattr(_resource, term) == value:
+                                return [_resource]
+
+                    return []
+                else:
+                    return resourcePart
+        else:
+            matches = []
+            for key in resources.keys():
+                matches.extend(self.__search([key] + parts[1:], resources, reqParams))
+            return matches
+
+    def __build_search(self, prefix=None, group=None, api_version=None, kind=None, **kwargs):
+        if not group and api_version and '/' in api_version:
+            group, api_version = api_version.split('/')
+
+        items = [prefix, group, api_version, kind, kwargs]
+        return list(map(lambda x: x or '*', items))
+
+    def __iter__(self):
+        for prefix, groups in self.__resources.items():
+            for group, versions in groups.items():
+                for version, rg in versions.items():
+                    # Request resources for this groupVersion if we haven't yet
+                    if not rg.resources:
+                        rg.resources = self.get_resources_for_api_version(
+                            prefix, group, version, rg.preferred)
+                        self._cache['resources'][prefix][group][version] = rg
+                        self.__update_cache = True
+                    for _, resource in six.iteritems(rg.resources):
+                        yield resource
+        self.__maybe_write_cache()
+
+
+class EagerDiscoverer(Discoverer):
+    """ A convenient container for storing discovered API resources. Allows
+        easy searching and retrieval of specific resources.
+
+        All resources are discovered for the cluster upon object instantiation.
+    """
+
+    def update(self, resources):
+        self.__resources = resources
+
+    def __init__(self, client, cache_file):
+        Discoverer.__init__(self, client, cache_file)
+
+    def discover(self):
+        self.__resources = self.parse_api_groups(request_resources=True)
+
+    @property
+    def api_groups(self):
+        """ list available api groups """
+        return self.parse_api_groups(request_resources=True, update=True)['apis'].keys()
+
+
+    def search(self, **kwargs):
+        """ Takes keyword arguments and returns matching resources. The search
+            will happen in the following order:
+                prefix: The api prefix for a resource, ie, /api, /oapi, /apis. Can usually be ignored
+                group: The api group of a resource. Will also be extracted from api_version if it is present there
+                api_version: The api version of a resource
+                kind: The kind of the resource
+                arbitrary arguments (see below), in random order
+
+            The arbitrary arguments can be any valid attribute for an Resource object
+        """
+        results = self.__search(self.__build_search(**kwargs), self.__resources)
+        if not results:
+            self.invalidate_cache()
+            results = self.__search(self.__build_search(**kwargs), self.__resources)
+        return results
+
+    def __build_search(self, prefix=None, group=None, api_version=None, kind=None, **kwargs):
+        if not group and api_version and '/' in api_version:
+            group, api_version = api_version.split('/')
+
+        items = [prefix, group, api_version, kind, kwargs]
+        return list(map(lambda x: x or '*', items))
+
+    def __search(self, parts, resources):
+        part = parts[0]
+        resourcePart = resources.get(part)
+
+        if part != '*' and resourcePart:
+            if isinstance(resourcePart, ResourceGroup):
+                return self.__search(parts[1:], resourcePart.resources)
+            elif isinstance(resourcePart, dict):
+                return self.__search(parts[1:], resourcePart)
+            else:
+                if parts[1] != '*' and isinstance(parts[1], dict):
+                    for _resource in resourcePart:
+                        for term, value in parts[1].items():
+                            if getattr(_resource, term) == value:
+                                return [_resource]
+                    return []
+                else:
+                    return resourcePart
+        elif part == '*':
+            matches = []
+            for key in resources.keys():
+                matches.extend(self.__search([key] + parts[1:], resources))
+            return matches
+        return []
+
+    def __iter__(self):
+        for _, groups in self.__resources.items():
+            for _, versions in groups.items():
+                for _, resources in versions.items():
+                    for _, resource in resources.items():
+                        yield resource
+
+
+class ResourceGroup(object):
+    """Helper class for Discoverer container"""
+    def __init__(self, preferred, resources=None):
+        self.preferred = preferred
+        self.resources = resources or {}
+
+    def to_dict(self):
+        return {
+            '_type': 'ResourceGroup',
+            'preferred': self.preferred,
+            'resources': self.resources,
+        }
+
+
+class CacheEncoder(json.JSONEncoder):
+
+    def default(self, o):
+        return o.to_dict()
+
+
+class CacheDecoder(json.JSONDecoder):
+    def __init__(self, client, *args, **kwargs):
+        self.client = client
+        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
+
+    def object_hook(self, obj):
+        if '_type' not in obj:
+            return obj
+        _type = obj.pop('_type')
+        if _type == 'Resource':
+            return Resource(client=self.client, **obj)
+        elif _type == 'ResourceList':
+            return ResourceList(self.client, **obj)
+        elif _type == 'ResourceGroup':
+            return ResourceGroup(obj['preferred'], resources=self.object_hook(obj['resources']))
+        return obj

--- a/dynamic/exceptions.py
+++ b/dynamic/exceptions.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import sys
+import traceback
+
+from kubernetes.client.rest import ApiException
+
+
+def api_exception(e):
+    """
+    Returns the proper Exception class for the given kubernetes.client.rest.ApiException object
+    https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#success-codes
+    """
+    _, _, exc_traceback = sys.exc_info()
+    tb = '\n'.join(traceback.format_tb(exc_traceback))
+    return {
+        400: BadRequestError,
+        401: UnauthorizedError,
+        403: ForbiddenError,
+        404: NotFoundError,
+        405: MethodNotAllowedError,
+        409: ConflictError,
+        410: GoneError,
+        422: UnprocessibleEntityError,
+        429: TooManyRequestsError,
+        500: InternalServerError,
+        503: ServiceUnavailableError,
+        504: ServerTimeoutError,
+    }.get(e.status, DynamicApiError)(e, tb)
+
+
+class DynamicApiError(ApiException):
+    """ Generic API Error for the dynamic client """
+    def __init__(self, e, tb=None):
+        self.status = e.status
+        self.reason = e.reason
+        self.body = e.body
+        self.headers = e.headers
+        self.original_traceback = tb
+
+    def __str__(self):
+        error_message = [str(self.status), "Reason: {}".format(self.reason)]
+        if self.headers:
+            error_message.append("HTTP response headers: {}".format(self.headers))
+
+        if self.body:
+            error_message.append("HTTP response body: {}".format(self.body))
+
+        if self.original_traceback:
+            error_message.append("Original traceback: \n{}".format(self.original_traceback))
+
+        return '\n'.join(error_message)
+
+    def summary(self):
+        if self.body:
+            if self.headers and self.headers.get('Content-Type') == 'application/json':
+                message = json.loads(self.body).get('message')
+                if message:
+                    return message
+
+            return self.body
+        else:
+            return "{} Reason: {}".format(self.status, self.reason)
+
+class ResourceNotFoundError(Exception):
+    """ Resource was not found in available APIs """
+class ResourceNotUniqueError(Exception):
+    """ Parameters given matched multiple API resources """
+
+class KubernetesValidateMissing(Exception):
+    """ kubernetes-validate is not installed """
+
+# HTTP Errors
+class BadRequestError(DynamicApiError):
+    """ 400: StatusBadRequest """
+class UnauthorizedError(DynamicApiError):
+    """ 401: StatusUnauthorized """
+class ForbiddenError(DynamicApiError):
+    """ 403: StatusForbidden """
+class NotFoundError(DynamicApiError):
+    """ 404: StatusNotFound """
+class MethodNotAllowedError(DynamicApiError):
+    """ 405: StatusMethodNotAllowed """
+class ConflictError(DynamicApiError):
+    """ 409: StatusConflict """
+class GoneError(DynamicApiError):
+    """ 410: StatusGone """
+class UnprocessibleEntityError(DynamicApiError):
+    """ 422: StatusUnprocessibleEntity """
+class TooManyRequestsError(DynamicApiError):
+    """ 429: StatusTooManyRequests """
+class InternalServerError(DynamicApiError):
+    """ 500: StatusInternalServer """
+class ServiceUnavailableError(DynamicApiError):
+    """ 503: StatusServiceUnavailable """
+class ServerTimeoutError(DynamicApiError):
+    """ 504: StatusServerTimeout """

--- a/dynamic/exceptions.py
+++ b/dynamic/exceptions.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/resource.py
+++ b/dynamic/resource.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import yaml
+from functools import partial
+
+from pprint import pformat
+
+
+class Resource(object):
+    """ Represents an API resource type, containing the information required to build urls for requests """
+
+    def __init__(self, prefix=None, group=None, api_version=None, kind=None,
+                 namespaced=False, verbs=None, name=None, preferred=False, client=None,
+                 singularName=None, shortNames=None, categories=None, subresources=None, **kwargs):
+
+        if None in (api_version, kind, prefix):
+            raise ValueError("At least prefix, kind, and api_version must be provided")
+
+        self.prefix = prefix
+        self.group = group
+        self.api_version = api_version
+        self.kind = kind
+        self.namespaced = namespaced
+        self.verbs = verbs
+        self.name = name
+        self.preferred = preferred
+        self.client = client
+        self.singular_name = singularName or (name[:-1] if name else "")
+        self.short_names = shortNames
+        self.categories = categories
+        self.subresources = {
+            k: Subresource(self, **v) for k, v in (subresources or {}).items()
+        }
+
+        self.extra_args = kwargs
+
+    def to_dict(self):
+        return {
+            '_type': 'Resource',
+            'prefix': self.prefix,
+            'group': self.group,
+            'api_version': self.api_version,
+            'kind': self.kind,
+            'namespaced': self.namespaced,
+            'verbs': self.verbs,
+            'name': self.name,
+            'preferred': self.preferred,
+            'singular_name': self.singular_name,
+            'short_names': self.short_names,
+            'categories': self.categories,
+            'subresources': {k: sr.to_dict() for k, sr in self.subresources.items()},
+            'extra_args': self.extra_args,
+        }
+
+    @property
+    def group_version(self):
+        if self.group:
+            return '{}/{}'.format(self.group, self.api_version)
+        return self.api_version
+
+    def __repr__(self):
+        return '<{}({}/{})>'.format(self.__class__.__name__, self.group_version, self.name)
+
+    @property
+    def urls(self):
+        full_prefix = '{}/{}'.format(self.prefix, self.group_version)
+        resource_name = self.name.lower()
+        return {
+            'base': '/{}/{}'.format(full_prefix, resource_name),
+            'namespaced_base': '/{}/namespaces/{{namespace}}/{}'.format(full_prefix, resource_name),
+            'full': '/{}/{}/{{name}}'.format(full_prefix, resource_name),
+            'namespaced_full': '/{}/namespaces/{{namespace}}/{}/{{name}}'.format(full_prefix, resource_name)
+        }
+
+    def path(self, name=None, namespace=None):
+        url_type = []
+        path_params = {}
+        if self.namespaced and namespace:
+            url_type.append('namespaced')
+            path_params['namespace'] = namespace
+        if name:
+            url_type.append('full')
+            path_params['name'] = name
+        else:
+            url_type.append('base')
+        return self.urls['_'.join(url_type)].format(**path_params)
+
+    def __getattr__(self, name):
+        if name in self.subresources:
+            return self.subresources[name]
+        return partial(getattr(self.client, name), self)
+
+
+class ResourceList(Resource):
+    """ Represents a list of API objects """
+
+    def __init__(self, client, group='', api_version='v1', base_kind='', kind=None):
+        self.client = client
+        self.group = group
+        self.api_version = api_version
+        self.kind = kind or '{}List'.format(base_kind)
+        self.base_kind = base_kind
+        self.__base_resource = None
+
+    def base_resource(self):
+        if self.__base_resource:
+            return self.__base_resource
+        elif self.base_kind:
+            self.__base_resource = self.client.resources.get(group=self.group, api_version=self.api_version, kind=self.base_kind)
+            return self.__base_resource
+        return None
+
+    def _items_to_resources(self, body):
+        """ Takes a List body and return a dictionary with the following structure:
+            {
+                'api_version': str,
+                'kind': str,
+                'items': [{
+                    'resource': Resource,
+                    'name': str,
+                    'namespace': str,
+                }]
+            }
+        """
+        if body is None:
+            raise ValueError("You must provide a body when calling methods on a ResourceList")
+
+        api_version = body['apiVersion']
+        kind = body['kind']
+        items = body.get('items')
+        if not items:
+            raise ValueError('The `items` field in the body must be populated when calling methods on a ResourceList')
+
+        if self.kind != kind:
+            raise ValueError('Methods on a {} must be called with a body containing the same kind. Receieved {} instead'.format(self.kind, kind))
+
+        return {
+            'api_version': api_version,
+            'kind': kind,
+            'items': [self._item_to_resource(item) for item in items]
+        }
+
+    def _item_to_resource(self, item):
+        metadata = item.get('metadata', {})
+        resource = self.base_resource()
+        if not resource:
+            api_version = item.get('apiVersion', self.api_version)
+            kind = item.get('kind', self.base_kind)
+            resource = self.client.resources.get(api_version=api_version, kind=kind)
+        return {
+            'resource': resource,
+            'definition': item,
+            'name': metadata.get('name'),
+            'namespace': metadata.get('namespace')
+        }
+
+    def get(self, body, name=None, namespace=None, **kwargs):
+        if name:
+            raise ValueError('Operations on ResourceList objects do not support the `name` argument')
+        resource_list = self._items_to_resources(body)
+        response = copy.deepcopy(body)
+
+        response['items'] = [
+            item['resource'].get(name=item['name'], namespace=item['namespace'] or namespace, **kwargs).to_dict()
+            for item in resource_list['items']
+        ]
+        return ResourceInstance(self, response)
+
+    def delete(self, body, name=None, namespace=None, **kwargs):
+        if name:
+            raise ValueError('Operations on ResourceList objects do not support the `name` argument')
+        resource_list = self._items_to_resources(body)
+        response = copy.deepcopy(body)
+
+        response['items'] = [
+            item['resource'].delete(name=item['name'], namespace=item['namespace'] or namespace, **kwargs).to_dict()
+            for item in resource_list['items']
+        ]
+        return ResourceInstance(self, response)
+
+    def verb_mapper(self, verb, body, **kwargs):
+        resource_list = self._items_to_resources(body)
+        response = copy.deepcopy(body)
+        response['items'] = [
+            getattr(item['resource'], verb)(body=item['definition'], **kwargs).to_dict()
+            for item in resource_list['items']
+        ]
+        return ResourceInstance(self, response)
+
+    def create(self, *args, **kwargs):
+        return self.verb_mapper('create', *args, **kwargs)
+
+    def replace(self, *args, **kwargs):
+        return self.verb_mapper('replace', *args, **kwargs)
+
+    def patch(self, *args, **kwargs):
+        return self.verb_mapper('patch', *args, **kwargs)
+
+    def to_dict(self):
+        return {
+            '_type': 'ResourceList',
+            'group': self.group,
+            'api_version': self.api_version,
+            'kind': self.kind,
+            'base_kind': self.base_kind
+        }
+
+    def __getattr__(self, name):
+        if self.base_resource():
+            return getattr(self.base_resource(), name)
+        return None
+
+
+class Subresource(Resource):
+    """ Represents a subresource of an API resource. This generally includes operations
+        like scale, as well as status objects for an instantiated resource
+    """
+
+    def __init__(self, parent, **kwargs):
+        self.parent = parent
+        self.prefix = parent.prefix
+        self.group = parent.group
+        self.api_version = parent.api_version
+        self.kind = kwargs.pop('kind')
+        self.name = kwargs.pop('name')
+        self.subresource = self.name.split('/')[1]
+        self.namespaced = kwargs.pop('namespaced', False)
+        self.verbs = kwargs.pop('verbs', None)
+        self.extra_args = kwargs
+
+    #TODO(fabianvf): Determine proper way to handle differences between resources + subresources
+    def create(self, body=None, name=None, namespace=None, **kwargs):
+        name = name or body.get('metadata', {}).get('name')
+        body = self.parent.client.serialize_body(body)
+        if self.parent.namespaced:
+            namespace = self.parent.client.ensure_namespace(self.parent, namespace, body)
+        path = self.path(name=name, namespace=namespace)
+        return self.parent.client.request('post', path, body=body, **kwargs)
+
+    @property
+    def urls(self):
+        full_prefix = '{}/{}'.format(self.prefix, self.group_version)
+        return {
+            'full': '/{}/{}/{{name}}/{}'.format(full_prefix, self.parent.name, self.subresource),
+            'namespaced_full': '/{}/namespaces/{{namespace}}/{}/{{name}}/{}'.format(full_prefix, self.parent.name, self.subresource)
+        }
+
+    def __getattr__(self, name):
+        return partial(getattr(self.parent.client, name), self)
+
+    def to_dict(self):
+        return {
+            'kind': self.kind,
+            'name': self.name,
+            'subresource': self.subresource,
+            'namespaced': self.namespaced,
+            'verbs': self.verbs,
+            'extra_args': self.extra_args,
+        }
+
+
+class ResourceInstance(object):
+    """ A parsed instance of an API resource. It exists solely to
+        ease interaction with API objects by allowing attributes to
+        be accessed with '.' notation.
+    """
+
+    def __init__(self, client, instance):
+        self.client = client
+        # If we have a list of resources, then set the apiVersion and kind of
+        # each resource in 'items'
+        kind = instance['kind']
+        if kind.endswith('List') and 'items' in instance:
+            kind = instance['kind'][:-4]
+            for item in instance['items']:
+                if 'apiVersion' not in item:
+                    item['apiVersion'] = instance['apiVersion']
+                if 'kind' not in item:
+                    item['kind'] = kind
+
+        self.attributes = self.__deserialize(instance)
+        self.__initialised = True
+
+    def __deserialize(self, field):
+        if isinstance(field, dict):
+            return ResourceField(**{
+                k: self.__deserialize(v) for k, v in field.items()
+            })
+        elif isinstance(field, (list, tuple)):
+            return [self.__deserialize(item) for item in field]
+        else:
+            return field
+
+    def __serialize(self, field):
+        if isinstance(field, ResourceField):
+            return {
+                k: self.__serialize(v) for k, v in field.__dict__.items()
+            }
+        elif isinstance(field, (list, tuple)):
+            return [self.__serialize(item) for item in field]
+        elif isinstance(field, ResourceInstance):
+            return field.to_dict()
+        else:
+            return field
+
+    def to_dict(self):
+        return self.__serialize(self.attributes)
+
+    def to_str(self):
+        return repr(self)
+
+    def __repr__(self):
+        return "ResourceInstance[{}]:\n  {}".format(
+            self.attributes.kind,
+            '  '.join(yaml.safe_dump(self.to_dict()).splitlines(True))
+        )
+
+    def __getattr__(self, name):
+        if not '_ResourceInstance__initialised' in self.__dict__:
+            return super(ResourceInstance, self).__getattr__(name)
+        return getattr(self.attributes, name)
+
+    def __setattr__(self, name, value):
+        if not '_ResourceInstance__initialised' in self.__dict__:
+            return super(ResourceInstance, self).__setattr__(name, value)
+        elif name in self.__dict__:
+            return super(ResourceInstance, self).__setattr__(name, value)
+        else:
+            self.attributes[name] = value
+
+    def __getitem__(self, name):
+        return self.attributes[name]
+
+    def __setitem__(self, name, value):
+        self.attributes[name] = value
+
+    def __dir__(self):
+        return dir(type(self)) + list(self.attributes.__dict__.keys())
+
+
+class ResourceField(object):
+    """ A parsed instance of an API resource attribute. It exists
+        solely to ease interaction with API objects by allowing
+        attributes to be accessed with '.' notation
+    """
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def __repr__(self):
+        return pformat(self.__dict__)
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def __getitem__(self, name):
+        return self.__dict__.get(name)
+
+    # Here resource.items will return items if available or resource.__dict__.items function if not
+    # resource.get will call resource.__dict__.get after attempting resource.__dict__.get('get')
+    def __getattr__(self, name):
+        return self.__dict__.get(name, getattr(self.__dict__, name, None))
+
+    def __setattr__(self, name, value):
+        self.__dict__[name] = value
+
+    def __dir__(self):
+        return dir(type(self)) + list(self.__dict__.keys())
+
+    def __iter__(self):
+        for k, v in self.__dict__.items():
+            yield (k, v)

--- a/dynamic/resource.py
+++ b/dynamic/resource.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -41,7 +41,9 @@ class TestDynamicClient(unittest.TestCase):
             changeme_api = client.resources.get(
                 api_version='apps.example.com/v1', kind='ClusterChangeMe')
 
-        crd_api = client.resources.get(kind='CustomResourceDefinition')
+        crd_api = client.resources.get(
+            api_version='apiextensions.k8s.io/v1beta1',
+            kind='CustomResourceDefinition')
         name = 'clusterchangemes.apps.example.com'
         crd_manifest = {
             'apiVersion': 'apiextensions.k8s.io/v1beta1',
@@ -138,7 +140,9 @@ class TestDynamicClient(unittest.TestCase):
             changeme_api = client.resources.get(
                 api_version='apps.example.com/v1', kind='ChangeMe')
 
-        crd_api = client.resources.get(kind='CustomResourceDefinition')
+        crd_api = client.resources.get(
+            api_version='apiextensions.k8s.io/v1beta1',
+            kind='CustomResourceDefinition')
         name = 'changemes.apps.example.com'
         crd_manifest = {
             'apiVersion': 'apiextensions.k8s.io/v1beta1',

--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -359,7 +359,7 @@ class TestDynamicClient(unittest.TestCase):
 
         resp = api.get(namespace='default', pretty=True, label_selector="e2e-test=true")
         self.assertEqual([], resp.items)
-
+    
     def test_node_apis(self):
         client = DynamicClient(api_client.ApiClient(configuration=self.config))
         api = client.resources.get(api_version='v1', kind='Node')
@@ -367,3 +367,19 @@ class TestDynamicClient(unittest.TestCase):
         for item in api.get().items:
             node = api.get(name=item.metadata.name)
             self.assertTrue(len(dict(node.metadata.labels)) > 0)
+    
+    # test_node_apis_partial_object_metadata lists all nodes in the cluster, but only retrieves object metadata
+    def test_node_apis_partial_object_metadata(self):
+        client = DynamicClient(api_client.ApiClient(configuration=self.config))
+        api = client.resources.get(api_version='v1', kind='Node')
+        
+        params = {'header_params': {'Accept': 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io'}}
+        resp = api.get(**params)
+        self.assertEqual('PartialObjectMetadataList', resp.kind)
+        self.assertEqual('meta.k8s.io/v1', resp.apiVersion)
+
+        params = {'header_params': {'aCcePt': 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io'}}
+        resp = api.get(**params)
+        self.assertEqual('PartialObjectMetadataList', resp.kind)
+        self.assertEqual('meta.k8s.io/v1', resp.apiVersion)
+

--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+import uuid
+
+from kubernetes.e2e_test import base
+from kubernetes.client import api_client
+
+from . import DynamicClient
+from .exceptions import ResourceNotFoundError
+
+
+def short_uuid():
+    id = str(uuid.uuid4())
+    return id[-12:]
+
+
+class TestDynamicClient(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config = base.get_e2e_configuration()
+
+    def test_cluster_custom_resources(self):
+        client = DynamicClient(api_client.ApiClient(configuration=self.config))
+
+        with self.assertRaises(ResourceNotFoundError):
+            changeme_api = client.resources.get(
+                api_version='apps.example.com/v1', kind='ClusterChangeMe')
+
+        crd_api = client.resources.get(kind='CustomResourceDefinition')
+        name = 'clusterchangemes.apps.example.com'
+        crd_manifest = {
+            'apiVersion': 'apiextensions.k8s.io/v1beta1',
+            'kind': 'CustomResourceDefinition',
+            'metadata': {
+                'name': name,
+            },
+            'spec': {
+                'group': 'apps.example.com',
+                'names': {
+                    'kind': 'ClusterChangeMe',
+                    'listKind': 'ClusterChangeMeList',
+                    'plural': 'clusterchangemes',
+                    'singular': 'clusterchangeme',
+                },
+                'scope': 'Cluster',
+                'version': 'v1',
+                'subresources': {
+                    'status': {}
+                }
+            }
+        }
+        resp = crd_api.create(crd_manifest)
+
+        self.assertEqual(name, resp.metadata.name)
+        self.assertTrue(resp.status)
+
+        resp = crd_api.get(
+            name=name,
+        )
+        self.assertEqual(name, resp.metadata.name)
+        self.assertTrue(resp.status)
+
+        try:
+            changeme_api = client.resources.get(
+                api_version='apps.example.com/v1', kind='ClusterChangeMe')
+        except ResourceNotFoundError:
+            # Need to wait a sec for the discovery layer to get updated
+            time.sleep(2)
+        changeme_api = client.resources.get(
+            api_version='apps.example.com/v1', kind='ClusterChangeMe')
+        resp = changeme_api.get()
+        self.assertEqual(resp.items, [])
+        changeme_name = 'custom-resource' + short_uuid()
+        changeme_manifest = {
+            'apiVersion': 'apps.example.com/v1',
+            'kind': 'ClusterChangeMe',
+            'metadata': {
+                'name': changeme_name,
+            },
+            'spec': {}
+        }
+
+        resp = changeme_api.create(body=changeme_manifest)
+        self.assertEqual(resp.metadata.name, changeme_name)
+
+        resp = changeme_api.get(name=changeme_name)
+        self.assertEqual(resp.metadata.name, changeme_name)
+
+        changeme_manifest['spec']['size'] = 3
+        resp = changeme_api.patch(
+            body=changeme_manifest,
+            content_type='application/merge-patch+json'
+        )
+        self.assertEqual(resp.spec.size, 3)
+
+        resp = changeme_api.get(name=changeme_name)
+        self.assertEqual(resp.spec.size, 3)
+
+        resp = changeme_api.get()
+        self.assertEqual(len(resp.items), 1)
+
+        resp = changeme_api.delete(
+            name=changeme_name,
+        )
+
+        resp = changeme_api.get()
+        self.assertEqual(len(resp.items), 0)
+
+        resp = crd_api.delete(
+            name=name,
+        )
+
+        time.sleep(2)
+        client.resources.invalidate_cache()
+        with self.assertRaises(ResourceNotFoundError):
+            changeme_api = client.resources.get(
+                api_version='apps.example.com/v1', kind='ClusterChangeMe')
+
+    def test_namespaced_custom_resources(self):
+        client = DynamicClient(api_client.ApiClient(configuration=self.config))
+
+        with self.assertRaises(ResourceNotFoundError):
+            changeme_api = client.resources.get(
+                api_version='apps.example.com/v1', kind='ChangeMe')
+
+        crd_api = client.resources.get(kind='CustomResourceDefinition')
+        name = 'changemes.apps.example.com'
+        crd_manifest = {
+            'apiVersion': 'apiextensions.k8s.io/v1beta1',
+            'kind': 'CustomResourceDefinition',
+            'metadata': {
+                'name': name,
+            },
+            'spec': {
+                'group': 'apps.example.com',
+                'names': {
+                    'kind': 'ChangeMe',
+                    'listKind': 'ChangeMeList',
+                    'plural': 'changemes',
+                    'singular': 'changeme',
+                },
+                'scope': 'Namespaced',
+                'version': 'v1',
+                'subresources': {
+                    'status': {}
+                }
+            }
+        }
+        resp = crd_api.create(crd_manifest)
+
+        self.assertEqual(name, resp.metadata.name)
+        self.assertTrue(resp.status)
+
+        resp = crd_api.get(
+            name=name,
+        )
+        self.assertEqual(name, resp.metadata.name)
+        self.assertTrue(resp.status)
+
+        try:
+            changeme_api = client.resources.get(
+                api_version='apps.example.com/v1', kind='ChangeMe')
+        except ResourceNotFoundError:
+            # Need to wait a sec for the discovery layer to get updated
+            time.sleep(2)
+        changeme_api = client.resources.get(
+            api_version='apps.example.com/v1', kind='ChangeMe')
+        resp = changeme_api.get()
+        self.assertEqual(resp.items, [])
+        changeme_name = 'custom-resource' + short_uuid()
+        changeme_manifest = {
+            'apiVersion': 'apps.example.com/v1',
+            'kind': 'ChangeMe',
+            'metadata': {
+                'name': changeme_name,
+            },
+            'spec': {}
+        }
+
+        resp = changeme_api.create(body=changeme_manifest, namespace='default')
+        self.assertEqual(resp.metadata.name, changeme_name)
+
+        resp = changeme_api.get(name=changeme_name, namespace='default')
+        self.assertEqual(resp.metadata.name, changeme_name)
+
+        changeme_manifest['spec']['size'] = 3
+        resp = changeme_api.patch(
+            body=changeme_manifest,
+            namespace='default',
+            content_type='application/merge-patch+json'
+        )
+        self.assertEqual(resp.spec.size, 3)
+
+        resp = changeme_api.get(name=changeme_name, namespace='default')
+        self.assertEqual(resp.spec.size, 3)
+
+        resp = changeme_api.get(namespace='default')
+        self.assertEqual(len(resp.items), 1)
+
+        resp = changeme_api.get()
+        self.assertEqual(len(resp.items), 1)
+
+        resp = changeme_api.delete(
+            name=changeme_name,
+            namespace='default'
+        )
+
+        resp = changeme_api.get(namespace='default')
+        self.assertEqual(len(resp.items), 0)
+
+        resp = changeme_api.get()
+        self.assertEqual(len(resp.items), 0)
+
+        resp = crd_api.delete(
+            name=name,
+        )
+
+        time.sleep(2)
+        client.resources.invalidate_cache()
+        with self.assertRaises(ResourceNotFoundError):
+            changeme_api = client.resources.get(
+                api_version='apps.example.com/v1', kind='ChangeMe')
+
+    def test_service_apis(self):
+        client = DynamicClient(api_client.ApiClient(configuration=self.config))
+        api = client.resources.get(api_version='v1', kind='Service')
+
+        name = 'frontend-' + short_uuid()
+        service_manifest = {'apiVersion': 'v1',
+                            'kind': 'Service',
+                            'metadata': {'labels': {'name': name},
+                                         'name': name,
+                                         'resourceversion': 'v1'},
+                            'spec': {'ports': [{'name': 'port',
+                                                'port': 80,
+                                                'protocol': 'TCP',
+                                                'targetPort': 80}],
+                                     'selector': {'name': name}}}
+
+        resp = api.create(
+            body=service_manifest,
+            namespace='default'
+        )
+        self.assertEqual(name, resp.metadata.name)
+        self.assertTrue(resp.status)
+
+        resp = api.get(
+            name=name,
+            namespace='default'
+        )
+        self.assertEqual(name, resp.metadata.name)
+        self.assertTrue(resp.status)
+
+        service_manifest['spec']['ports'] = [{'name': 'new',
+                                              'port': 8080,
+                                              'protocol': 'TCP',
+                                              'targetPort': 8080}]
+        resp = api.patch(
+            body=service_manifest,
+            name=name,
+            namespace='default'
+        )
+        self.assertEqual(2, len(resp.spec.ports))
+        self.assertTrue(resp.status)
+
+        resp = api.delete(
+            name=name, body={},
+            namespace='default'
+        )
+
+    def test_replication_controller_apis(self):
+        client = DynamicClient(api_client.ApiClient(configuration=self.config))
+        api = client.resources.get(
+            api_version='v1', kind='ReplicationController')
+
+        name = 'frontend-' + short_uuid()
+        rc_manifest = {
+            'apiVersion': 'v1',
+            'kind': 'ReplicationController',
+            'metadata': {'labels': {'name': name},
+                         'name': name},
+            'spec': {'replicas': 2,
+                     'selector': {'name': name},
+                     'template': {'metadata': {
+                         'labels': {'name': name}},
+                         'spec': {'containers': [{
+                             'image': 'nginx',
+                             'name': 'nginx',
+                             'ports': [{'containerPort': 80,
+                                        'protocol': 'TCP'}]}]}}}}
+
+        resp = api.create(
+            body=rc_manifest, namespace='default')
+        self.assertEqual(name, resp.metadata.name)
+        self.assertEqual(2, resp.spec.replicas)
+
+        resp = api.get(
+            name=name, namespace='default')
+        self.assertEqual(name, resp.metadata.name)
+        self.assertEqual(2, resp.spec.replicas)
+
+        resp = api.delete(
+            name=name, body={}, namespace='default')
+
+    def test_configmap_apis(self):
+        client = DynamicClient(api_client.ApiClient(configuration=self.config))
+        api = client.resources.get(api_version='v1', kind='ConfigMap')
+
+        name = 'test-configmap-' + short_uuid()
+        test_configmap = {
+            "kind": "ConfigMap",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": name,
+            },
+            "data": {
+                "config.json": "{\"command\":\"/usr/bin/mysqld_safe\"}",
+                "frontend.cnf": "[mysqld]\nbind-address = 10.0.0.3\n"
+            }
+        }
+
+        resp = api.create(
+            body=test_configmap, namespace='default'
+        )
+        self.assertEqual(name, resp.metadata.name)
+
+        resp = api.get(
+            name=name, namespace='default')
+        self.assertEqual(name, resp.metadata.name)
+
+        test_configmap['data']['config.json'] = "{}"
+        resp = api.patch(
+            name=name, namespace='default', body=test_configmap)
+
+        resp = api.delete(
+            name=name, body={}, namespace='default')
+
+        resp = api.get(namespace='default', pretty=True)
+        self.assertEqual([], resp.items)
+
+    def test_node_apis(self):
+        client = DynamicClient(api_client.ApiClient(configuration=self.config))
+        api = client.resources.get(api_version='v1', kind='Node')
+
+        for item in api.get().items:
+            node = api.get(name=item.metadata.name)
+            self.assertTrue(len(dict(node.metadata.labels)) > 0)

--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -318,8 +318,10 @@ class TestDynamicClient(unittest.TestCase):
         self.assertEqual(name, resp.metadata.name)
         self.assertEqual(2, resp.spec.replicas)
 
-        resp = api.delete(
-            name=name, body={}, namespace='default')
+        api.delete(
+            name=name,
+            namespace='default',
+            propagation_policy='Background')
 
     def test_configmap_apis(self):
         client = DynamicClient(api_client.ApiClient(configuration=self.config))
@@ -357,9 +359,12 @@ class TestDynamicClient(unittest.TestCase):
         resp = api.delete(
             name=name, body={}, namespace='default')
 
-        resp = api.get(namespace='default', pretty=True, label_selector="e2e-test=true")
+        resp = api.get(
+            namespace='default',
+            pretty=True,
+            label_selector="e2e-test=true")
         self.assertEqual([], resp.items)
-    
+
     def test_node_apis(self):
         client = DynamicClient(api_client.ApiClient(configuration=self.config))
         api = client.resources.get(api_version='v1', kind='Node')
@@ -367,19 +372,23 @@ class TestDynamicClient(unittest.TestCase):
         for item in api.get().items:
             node = api.get(name=item.metadata.name)
             self.assertTrue(len(dict(node.metadata.labels)) > 0)
-    
-    # test_node_apis_partial_object_metadata lists all nodes in the cluster, but only retrieves object metadata
+
+    # test_node_apis_partial_object_metadata lists all nodes in the cluster,
+    # but only retrieves object metadata
     def test_node_apis_partial_object_metadata(self):
         client = DynamicClient(api_client.ApiClient(configuration=self.config))
         api = client.resources.get(api_version='v1', kind='Node')
-        
-        params = {'header_params': {'Accept': 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io'}}
+
+        params = {
+            'header_params': {
+                'Accept': 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io'}}
         resp = api.get(**params)
         self.assertEqual('PartialObjectMetadataList', resp.kind)
         self.assertEqual('meta.k8s.io/v1', resp.apiVersion)
 
-        params = {'header_params': {'aCcePt': 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io'}}
+        params = {
+            'header_params': {
+                'aCcePt': 'application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io'}}
         resp = api.get(**params)
         self.assertEqual('PartialObjectMetadataList', resp.kind)
         self.assertEqual('meta.k8s.io/v1', resp.apiVersion)
-

--- a/dynamic/test_client.py
+++ b/dynamic/test_client.py
@@ -331,6 +331,9 @@ class TestDynamicClient(unittest.TestCase):
             "apiVersion": "v1",
             "metadata": {
                 "name": name,
+                "labels": {
+                    "e2e-test": "true",
+                },
             },
             "data": {
                 "config.json": "{\"command\":\"/usr/bin/mysqld_safe\"}",
@@ -344,7 +347,7 @@ class TestDynamicClient(unittest.TestCase):
         self.assertEqual(name, resp.metadata.name)
 
         resp = api.get(
-            name=name, namespace='default')
+            name=name, namespace='default', label_selector="e2e-test=true")
         self.assertEqual(name, resp.metadata.name)
 
         test_configmap['data']['config.json'] = "{}"
@@ -354,7 +357,7 @@ class TestDynamicClient(unittest.TestCase):
         resp = api.delete(
             name=name, body={}, namespace='default')
 
-        resp = api.get(namespace='default', pretty=True)
+        resp = api.get(namespace='default', pretty=True, label_selector="e2e-test=true")
         self.assertEqual([], resp.items)
 
     def test_node_apis(self):

--- a/dynamic/test_discovery.py
+++ b/dynamic/test_discovery.py
@@ -1,0 +1,40 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from kubernetes.e2e_test import base
+from kubernetes.client import api_client
+
+from . import DynamicClient
+
+
+class TestDiscoverer(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config = base.get_e2e_configuration()
+
+    def test_init_cache_from_file(self):
+        client = DynamicClient(api_client.ApiClient(configuration=self.config))
+        client.resources.get(api_version='v1', kind='Node')
+        mtime1 = os.path.getmtime(client.resources._Discoverer__cache_file)
+
+        client = DynamicClient(api_client.ApiClient(configuration=self.config))
+        client.resources.get(api_version='v1', kind='Node')
+        mtime2 = os.path.getmtime(client.resources._Discoverer__cache_file)
+
+        # test no Discoverer._write_cache called
+        self.assertTrue(mtime1 == mtime2)

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -24,6 +24,10 @@ import os
 import re
 import sys
 
+# list all the files contain a shebang line and should be ignored by this
+# script
+SKIP_FILES = ['hack/boilerplate/boilerplate.py']
+
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "filenames",
@@ -132,10 +136,6 @@ def file_extension(filename):
     return os.path.splitext(filename)[1].split(".")[-1].lower()
 
 
-# list all the files contain 'DO NOT EDIT', but are not generated
-skipped_ungenerated_files = ['hack/boilerplate/boilerplate.py']
-
-
 def normalize_files(files):
     newfiles = []
     for pathname in files:
@@ -143,10 +143,12 @@ def normalize_files(files):
     for i, pathname in enumerate(newfiles):
         if not os.path.isabs(pathname):
             newfiles[i] = os.path.join(args.rootdir, pathname)
+
     return newfiles
 
 
 def get_files(extensions):
+
     files = []
     if len(args.filenames) > 0:
         files = args.filenames
@@ -163,6 +165,8 @@ def get_files(extensions):
         extension = file_extension(pathname)
         if extension in extensions or basename in extensions:
             outfiles.append(pathname)
+
+    outfiles = list(set(outfiles) - set(normalize_files(SKIP_FILES)))
     return outfiles
 
 

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright YEAR The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/leaderelection/README.md
+++ b/leaderelection/README.md
@@ -1,0 +1,18 @@
+## Leader Election Example  
+This example demonstrates how to use the leader election library.
+
+## Running
+Run the following command in multiple separate terminals preferably an odd number. 
+Each running process uses a unique identifier displayed when it starts to run.
+
+- When a program runs, if a lock object already exists with the specified name, 
+all candidates will start as followers. 
+- If a lock object does not exist with the specified name then whichever candidate 
+creates a lock object first will become the leader and the rest will be followers.
+- The user will be prompted about the status of the candidates and transitions. 
+
+### Command to run
+```python example.py```
+
+Now kill the existing leader. You will see from the terminal outputs that one of the
+ remaining running processes will be elected as the new leader.

--- a/leaderelection/__init__.py
+++ b/leaderelection/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/leaderelection/electionconfig.py
+++ b/leaderelection/electionconfig.py
@@ -1,0 +1,59 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import logging
+logging.basicConfig(level=logging.INFO)
+
+
+class Config:
+    # Validate config, exit if an error is detected
+    def __init__(self, lock, lease_duration, renew_deadline, retry_period, onstarted_leading, onstopped_leading):
+        self.jitter_factor = 1.2
+
+        if lock is None:
+            sys.exit("lock cannot be None")
+        self.lock = lock
+
+        if lease_duration <= renew_deadline:
+            sys.exit("lease_duration must be greater than renew_deadline")
+
+        if renew_deadline <= self.jitter_factor * retry_period:
+            sys.exit("renewDeadline must be greater than retry_period*jitter_factor")
+
+        if lease_duration < 1:
+            sys.exit("lease_duration must be greater than one")
+
+        if renew_deadline < 1:
+            sys.exit("renew_deadline must be greater than one")
+
+        if retry_period < 1:
+            sys.exit("retry_period must be greater than one")
+
+        self.lease_duration = lease_duration
+        self.renew_deadline = renew_deadline
+        self.retry_period = retry_period
+
+        if onstarted_leading is None:
+            sys.exit("callback onstarted_leading cannot be None")
+        self.onstarted_leading = onstarted_leading
+
+        if onstopped_leading is None:
+            self.onstopped_leading = self.on_stoppedleading_callback
+        else:
+            self.onstopped_leading = onstopped_leading
+
+    # Default callback for when the current candidate if a leader, stops leading
+    def on_stoppedleading_callback(self):
+        logging.info("stopped leading".format(self.lock.identity))

--- a/leaderelection/example.py
+++ b/leaderelection/example.py
@@ -1,0 +1,54 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+from kubernetes import client, config
+from leaderelection import leaderelection
+from leaderelection.resourcelock.configmaplock import ConfigMapLock
+from leaderelection import electionconfig
+
+
+# Authenticate using config file
+config.load_kube_config(config_file=r"")
+
+# Parameters required from the user
+
+# A unique identifier for this candidate
+candidate_id = uuid.uuid4()
+
+# Name of the lock object to be created
+lock_name = "examplepython"
+
+# Kubernetes namespace
+lock_namespace = "default"
+
+
+# The function that a user wants to run once a candidate is elected as a leader
+def example_func():
+    print("I am leader")
+
+
+# A user can choose not to provide any callbacks for what to do when a candidate fails to lead - onStoppedLeading()
+# In that case, a default callback function will be used
+
+# Create config
+config = electionconfig.Config(ConfigMapLock(lock_name, lock_namespace, candidate_id), lease_duration=17,
+                               renew_deadline=15, retry_period=5, onstarted_leading=example_func,
+                               onstopped_leading=None)
+
+# Enter leader election
+leaderelection.LeaderElection(config).run()
+
+# User can choose to do another round of election or simply exit
+print("Exited leader election")

--- a/leaderelection/leaderelection.py
+++ b/leaderelection/leaderelection.py
@@ -1,0 +1,191 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import sys
+import time
+import json
+import threading
+from .leaderelectionrecord import LeaderElectionRecord
+import logging
+# if condition to be removed when support for python2 will be removed
+if sys.version_info > (3, 0):
+    from http import HTTPStatus
+else:
+    import httplib
+logging.basicConfig(level=logging.INFO)
+
+"""
+This package implements leader election using an annotation in a Kubernetes object.
+The onstarted_leading function is run in a thread and when it returns, if it does 
+it might not be safe to run it again in a process.
+
+At first all candidates are considered followers. The one to create a lock or update
+an existing lock first becomes the leader and remains so until it keeps renewing its
+lease.
+"""
+
+
+class LeaderElection:
+    def __init__(self, election_config):
+        if election_config is None:
+            sys.exit("argument config not passed")
+
+        # Latest record observed in the created lock object
+        self.observed_record = None
+
+        # The configuration set for this candidate
+        self.election_config = election_config
+
+        # Latest update time of the lock
+        self.observed_time_milliseconds = 0
+
+    # Point of entry to Leader election
+    def run(self):
+        # Try to create/ acquire a lock
+        if self.acquire():
+            logging.info("{} successfully acquired lease".format(self.election_config.lock.identity))
+
+            # Start leading and call OnStartedLeading()
+            threading.daemon = True
+            threading.Thread(target=self.election_config.onstarted_leading).start()
+
+            self.renew_loop()
+
+            # Failed to update lease, run OnStoppedLeading callback
+            self.election_config.onstopped_leading()
+
+    def acquire(self):
+        # Follower
+        logging.info("{} is a follower".format(self.election_config.lock.identity))
+        retry_period = self.election_config.retry_period
+
+        while True:
+            succeeded = self.try_acquire_or_renew()
+
+            if succeeded:
+                return True
+
+            time.sleep(retry_period)
+
+    def renew_loop(self):
+        # Leader
+        logging.info("Leader has entered renew loop and will try to update lease continuously")
+
+        retry_period = self.election_config.retry_period
+        renew_deadline = self.election_config.renew_deadline * 1000
+
+        while True:
+            timeout = int(time.time() * 1000) + renew_deadline
+            succeeded = False
+
+            while int(time.time() * 1000) < timeout:
+                succeeded = self.try_acquire_or_renew()
+
+                if succeeded:
+                    break
+                time.sleep(retry_period)
+
+            if succeeded:
+                time.sleep(retry_period)
+                continue
+
+            # failed to renew, return
+            return
+
+    def try_acquire_or_renew(self):
+        now_timestamp = time.time()
+        now = datetime.datetime.fromtimestamp(now_timestamp)
+
+        # Check if lock is created
+        lock_status, old_election_record = self.election_config.lock.get(self.election_config.lock.name,
+                                                                        self.election_config.lock.namespace)
+
+        # create a default Election record for this candidate
+        leader_election_record = LeaderElectionRecord(self.election_config.lock.identity,
+                                                     str(self.election_config.lease_duration), str(now), str(now))
+
+        # A lock is not created with that name, try to create one
+        if not lock_status:
+            # To be removed when support for python2 will be removed
+            if sys.version_info > (3, 0):
+                if json.loads(old_election_record.body)['code'] != HTTPStatus.NOT_FOUND:
+                    logging.info("Error retrieving resource lock {} as {}".format(self.election_config.lock.name,
+                                                                                  old_election_record.reason))
+                    return False
+            else:
+                if json.loads(old_election_record.body)['code'] != httplib.NOT_FOUND:
+                    logging.info("Error retrieving resource lock {} as {}".format(self.election_config.lock.name,
+                                                                                  old_election_record.reason))
+                    return False
+
+            logging.info("{} is trying to create a lock".format(leader_election_record.holder_identity))
+            create_status = self.election_config.lock.create(name=self.election_config.lock.name,
+                                                             namespace=self.election_config.lock.namespace,
+                                                             election_record=leader_election_record)
+
+            if create_status is False:
+                logging.info("{} Failed to create lock".format(leader_election_record.holder_identity))
+                return False
+
+            self.observed_record = leader_election_record
+            self.observed_time_milliseconds = int(time.time() * 1000)
+            return True
+
+        # A lock exists with that name
+        # Validate old_election_record
+        if old_election_record is None:
+            # try to update lock with proper annotation and election record
+            return self.update_lock(leader_election_record)
+
+        if (old_election_record.holder_identity is None or old_election_record.lease_duration is None
+                or old_election_record.acquire_time is None or old_election_record.renew_time is None):
+            # try to update lock with proper annotation and election record
+            return self.update_lock(leader_election_record)
+
+        # Report transitions
+        if self.observed_record and self.observed_record.holder_identity != old_election_record.holder_identity:
+            logging.info("Leader has switched to {}".format(old_election_record.holder_identity))
+
+        if self.observed_record is None or old_election_record.__dict__ != self.observed_record.__dict__:
+            self.observed_record = old_election_record
+            self.observed_time_milliseconds = int(time.time() * 1000)
+
+        # If This candidate is not the leader and lease duration is yet to finish
+        if (self.election_config.lock.identity != self.observed_record.holder_identity
+                and self.observed_time_milliseconds + self.election_config.lease_duration * 1000 > int(now_timestamp * 1000)):
+            logging.info("yet to finish lease_duration, lease held by {} and has not expired".format(old_election_record.holder_identity))
+            return False
+
+        # If this candidate is the Leader
+        if self.election_config.lock.identity == self.observed_record.holder_identity:
+            # Leader updates renewTime, but keeps acquire_time unchanged
+            leader_election_record.acquire_time = self.observed_record.acquire_time
+
+        return self.update_lock(leader_election_record)
+
+    def update_lock(self, leader_election_record):
+        # Update object with latest election record
+        update_status = self.election_config.lock.update(self.election_config.lock.name,
+                                                         self.election_config.lock.namespace,
+                                                         leader_election_record)
+
+        if update_status is False:
+            logging.info("{} failed to acquire lease".format(leader_election_record.holder_identity))
+            return False
+
+        self.observed_record = leader_election_record
+        self.observed_time_milliseconds = int(time.time() * 1000)
+        logging.info("leader {} has successfully acquired lease".format(leader_election_record.holder_identity))
+        return True

--- a/leaderelection/leaderelection_test.py
+++ b/leaderelection/leaderelection_test.py
@@ -1,0 +1,270 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from . import leaderelection
+from .leaderelectionrecord import LeaderElectionRecord
+from kubernetes.client.rest import ApiException
+from . import electionconfig
+import unittest
+import threading
+import json
+import time
+import pytest
+
+thread_lock = threading.RLock()
+
+class LeaderElectionTest(unittest.TestCase):
+    def test_simple_leader_election(self):
+        election_history = []
+        leadership_history = []
+
+        def on_create():
+            election_history.append("create record")
+            leadership_history.append("get leadership")
+
+        def on_update():
+            election_history.append("update record")
+
+        def on_change():
+            election_history.append("change record")
+
+        mock_lock = MockResourceLock("mock", "mock_namespace", "mock", thread_lock, on_create, on_update, on_change, None)
+
+        def on_started_leading():
+            leadership_history.append("start leading")
+
+        def on_stopped_leading():
+            leadership_history.append("stop leading")
+
+        # Create config 4.5 4 3
+        config = electionconfig.Config(lock=mock_lock, lease_duration=2.5,
+                                       renew_deadline=2, retry_period=1.5, onstarted_leading=on_started_leading,
+                                       onstopped_leading=on_stopped_leading)
+
+        # Enter leader election
+        leaderelection.LeaderElection(config).run()
+
+        self.assert_history(election_history, ["create record", "update record", "update record", "update record"])
+        self.assert_history(leadership_history, ["get leadership", "start leading", "stop leading"])
+
+    def test_leader_election(self):
+        election_history = []
+        leadership_history = []
+
+        def on_create_A():
+            election_history.append("A creates record")
+            leadership_history.append("A gets leadership")
+
+        def on_update_A():
+            election_history.append("A updates record")
+
+        def on_change_A():
+            election_history.append("A gets leadership")
+
+        mock_lock_A = MockResourceLock("mock", "mock_namespace", "MockA", thread_lock, on_create_A, on_update_A, on_change_A, None)
+        mock_lock_A.renew_count_max = 3
+
+        def on_started_leading_A():
+            leadership_history.append("A starts leading")
+
+        def on_stopped_leading_A():
+            leadership_history.append("A stops leading")
+
+        config_A = electionconfig.Config(lock=mock_lock_A, lease_duration=2.5,
+                                         renew_deadline=2, retry_period=1.5, onstarted_leading=on_started_leading_A,
+                                         onstopped_leading=on_stopped_leading_A)
+
+        def on_create_B():
+            election_history.append("B creates record")
+            leadership_history.append("B gets leadership")
+
+        def on_update_B():
+            election_history.append("B updates record")
+
+        def on_change_B():
+            leadership_history.append("B gets leadership")
+
+        mock_lock_B = MockResourceLock("mock", "mock_namespace", "MockB", thread_lock, on_create_B, on_update_B, on_change_B, None)
+        mock_lock_B.renew_count_max = 4
+
+        def on_started_leading_B():
+            leadership_history.append("B starts leading")
+
+        def on_stopped_leading_B():
+            leadership_history.append("B stops leading")
+
+        config_B = electionconfig.Config(lock=mock_lock_B, lease_duration=2.5,
+                                         renew_deadline=2, retry_period=1.5, onstarted_leading=on_started_leading_B,
+                                         onstopped_leading=on_stopped_leading_B)
+
+        mock_lock_B.leader_record = mock_lock_A.leader_record
+
+        threading.daemon = True
+        # Enter leader election for A
+        threading.Thread(target=leaderelection.LeaderElection(config_A).run()).start()
+
+        # Enter leader election for B
+        threading.Thread(target=leaderelection.LeaderElection(config_B).run()).start()
+
+        time.sleep(5)
+
+        self.assert_history(election_history,
+                            ["A creates record",
+                             "A updates record",
+                             "A updates record",
+                             "B updates record",
+                             "B updates record",
+                             "B updates record",
+                             "B updates record"])
+        self.assert_history(leadership_history,
+                            ["A gets leadership",
+                             "A starts leading",
+                             "A stops leading",
+                             "B gets leadership",
+                             "B starts leading",
+                             "B stops leading"])
+
+
+    """Expected behavior: to check if the leader stops leading if it fails to update the lock within the renew_deadline
+    and stops leading after finally timing out. The difference between each try comes out to be approximately the sleep
+    time.
+    Example:
+    create record:  0s
+    on try update:  1.5s
+    on update:  zzz s
+    on try update:  3s
+    on update: zzz s 
+    on try update:  4.5s
+    on try update:  6s
+    Timeout - Leader Exits"""
+    def test_Leader_election_with_renew_deadline(self):
+        election_history = []
+        leadership_history = []
+
+        def on_create():
+            election_history.append("create record")
+            leadership_history.append("get leadership")
+
+        def on_update():
+            election_history.append("update record")
+
+        def on_change():
+            election_history.append("change record")
+
+        def on_try_update():
+            election_history.append("try update record")
+
+        mock_lock = MockResourceLock("mock", "mock_namespace", "mock", thread_lock, on_create, on_update, on_change, on_try_update)
+        mock_lock.renew_count_max = 3
+
+        def on_started_leading():
+            leadership_history.append("start leading")
+
+        def on_stopped_leading():
+            leadership_history.append("stop leading")
+
+        # Create config
+        config = electionconfig.Config(lock=mock_lock, lease_duration=2.5,
+                                       renew_deadline=2, retry_period=1.5, onstarted_leading=on_started_leading,
+                                       onstopped_leading=on_stopped_leading)
+
+        # Enter leader election
+        leaderelection.LeaderElection(config).run()
+
+        self.assert_history(election_history,
+                            ["create record",
+                             "try update record",
+                             "update record",
+                             "try update record",
+                             "update record",
+                             "try update record",
+                             "try update record"])
+
+        self.assert_history(leadership_history, ["get leadership", "start leading", "stop leading"])
+
+    def assert_history(self, history, expected):
+        self.assertIsNotNone(expected)
+        self.assertIsNotNone(history)
+        self.assertEqual(len(expected), len(history))
+
+        for idx in range(len(history)):
+            self.assertEqual(history[idx], expected[idx],
+                              msg="Not equal at index {}, expected {}, got {}".format(idx, expected[idx],
+                                                                                      history[idx]))
+
+
+class MockResourceLock:
+    def __init__(self, name, namespace, identity, shared_lock, on_create=None, on_update=None, on_change=None, on_try_update=None):
+        # self.leader_record is shared between two MockResourceLock objects
+        self.leader_record = []
+        self.renew_count = 0
+        self.renew_count_max = 4
+        self.name = name
+        self.namespace = namespace
+        self.identity = str(identity)
+        self.lock = shared_lock
+
+        self.on_create = on_create
+        self.on_update = on_update
+        self.on_change = on_change
+        self.on_try_update = on_try_update
+
+    def get(self, name, namespace):
+        self.lock.acquire()
+        try:
+            if self.leader_record:
+                return True, self.leader_record[0]
+
+            ApiException.body = json.dumps({'code': 404})
+            return False, ApiException
+        finally:
+            self.lock.release()
+
+    def create(self, name, namespace, election_record):
+        self.lock.acquire()
+        try:
+            if len(self.leader_record) == 1:
+                return False
+            self.leader_record.append(election_record)
+            self.on_create()
+            self.renew_count += 1
+            return True
+        finally:
+            self.lock.release()
+
+    def update(self, name, namespace, updated_record):
+        self.lock.acquire()
+        try:
+            if self.on_try_update:
+                self.on_try_update()
+            if self.renew_count >= self.renew_count_max:
+                return False
+
+            old_record = self.leader_record[0]
+            self.leader_record[0] = updated_record
+
+            self.on_update()
+
+            if old_record.holder_identity != updated_record.holder_identity:
+                self.on_change()
+
+            self.renew_count += 1
+            return True
+        finally:
+            self.lock.release()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/leaderelection/leaderelectionrecord.py
+++ b/leaderelection/leaderelectionrecord.py
@@ -1,0 +1,22 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class LeaderElectionRecord:
+    # Annotation used in the lock object
+    def __init__(self, holder_identity, lease_duration, acquire_time, renew_time):
+        self.holder_identity = holder_identity
+        self.lease_duration = lease_duration
+        self.acquire_time = acquire_time
+        self.renew_time = renew_time

--- a/leaderelection/resourcelock/__init__.py
+++ b/leaderelection/resourcelock/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/leaderelection/resourcelock/configmaplock.py
+++ b/leaderelection/resourcelock/configmaplock.py
@@ -1,0 +1,129 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kubernetes.client.rest import ApiException
+from kubernetes import client, config
+from kubernetes.client.api_client import ApiClient
+from leaderelection.leaderelectionrecord import LeaderElectionRecord
+import json
+import logging
+logging.basicConfig(level=logging.INFO)
+
+
+class ConfigMapLock:
+    def __init__(self, name, namespace, identity):
+        """
+        :param name: name of the lock
+        :param namespace: namespace
+        :param identity: A unique identifier that the candidate is using
+        """
+        self.api_instance = client.CoreV1Api()
+        self.leader_electionrecord_annotationkey = 'control-plane.alpha.kubernetes.io/leader'
+        self.name = name
+        self.namespace = namespace
+        self.identity = str(identity)
+        self.configmap_reference = None
+        self.lock_record = {
+            'holderIdentity': None,
+            'leaseDurationSeconds': None,
+            'acquireTime': None,
+            'renewTime': None
+                            }
+
+    # get returns the election record from a ConfigMap Annotation
+    def get(self, name, namespace):
+        """
+        :param name: Name of the configmap object information to get
+        :param namespace: Namespace in which the configmap object is to be searched
+        :return: 'True, election record' if object found else 'False, exception response'
+        """
+        try:
+            api_response = self.api_instance.read_namespaced_config_map(name, namespace)
+
+            # If an annotation does not exist - add the leader_electionrecord_annotationkey
+            annotations = api_response.metadata.annotations
+            if annotations is None or annotations == '':
+                api_response.metadata.annotations = {self.leader_electionrecord_annotationkey: ''}
+                self.configmap_reference = api_response
+                return True, None
+
+            # If an annotation exists but, the leader_electionrecord_annotationkey does not then add it as a key
+            if not annotations.get(self.leader_electionrecord_annotationkey):
+                api_response.metadata.annotations = {self.leader_electionrecord_annotationkey: ''}
+                self.configmap_reference = api_response
+                return True, None
+
+            lock_record = self.get_lock_object(json.loads(annotations[self.leader_electionrecord_annotationkey]))
+
+            self.configmap_reference = api_response
+            return True, lock_record
+        except ApiException as e:
+            return False, e
+
+    def create(self, name, namespace, election_record):
+        """
+        :param electionRecord: Annotation string
+        :param name: Name of the configmap object to be created
+        :param namespace: Namespace in which the configmap object is to be created
+        :return: 'True' if object is created else 'False' if failed
+        """
+        body = client.V1ConfigMap(
+            metadata={"name": name,
+                      "annotations": {self.leader_electionrecord_annotationkey: json.dumps(self.get_lock_dict(election_record))}})
+
+        try:
+            api_response = self.api_instance.create_namespaced_config_map(namespace, body, pretty=True)
+            return True
+        except ApiException as e:
+            logging.info("Failed to create lock as {}".format(e))
+            return False
+
+    def update(self, name, namespace, updated_record):
+        """
+        :param name: name of the lock to be updated
+        :param namespace: namespace the lock is in
+        :param updated_record: the updated election record
+        :return: True if update is succesful False if it fails
+        """
+        try:
+            # Set the updated record
+            self.configmap_reference.metadata.annotations[self.leader_electionrecord_annotationkey] = json.dumps(self.get_lock_dict(updated_record))
+            api_response = self.api_instance.replace_namespaced_config_map(name=name, namespace=namespace,
+                                                                           body=self.configmap_reference)
+            return True
+        except ApiException as e:
+            logging.info("Failed to update lock as {}".format(e))
+            return False
+
+    def get_lock_object(self, lock_record):
+        leader_election_record = LeaderElectionRecord(None, None, None, None)
+
+        if lock_record.get('holderIdentity'):
+            leader_election_record.holder_identity = lock_record['holderIdentity']
+        if lock_record.get('leaseDurationSeconds'):
+            leader_election_record.lease_duration = lock_record['leaseDurationSeconds']
+        if lock_record.get('acquireTime'):
+            leader_election_record.acquire_time = lock_record['acquireTime']
+        if lock_record.get('renewTime'):
+            leader_election_record.renew_time = lock_record['renewTime']
+
+        return leader_election_record
+
+    def get_lock_dict(self, leader_election_record):
+        self.lock_record['holderIdentity'] = leader_election_record.holder_identity
+        self.lock_record['leaseDurationSeconds'] = leader_election_record.lease_duration
+        self.lock_record['acquireTime'] = leader_election_record.acquire_time
+        self.lock_record['renewTime'] = leader_election_record.renew_time
+        
+        return self.lock_record

--- a/stream/__init__.py
+++ b/stream/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .stream import stream
+from .stream import stream, portforward

--- a/stream/__init__.py
+++ b/stream/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/stream/stream.py
+++ b/stream/stream.py
@@ -17,9 +17,12 @@ import functools
 from . import ws_client
 
 
-def _websocket_reqeust(websocket_request, api_method, *args, **kwargs):
+def _websocket_reqeust(websocket_request, force_kwargs, api_method, *args, **kwargs):
     """Override the ApiClient.request method with an alternative websocket based
     method and call the supplied Kubernetes API method with that in place."""
+    if force_kwargs:
+        for kwarg, value in force_kwargs.items():
+            kwargs[kwarg] = value
     api_client = api_method.__self__.api_client
     # old generated code's api client has config. new ones has configuration
     try:
@@ -34,4 +37,5 @@ def _websocket_reqeust(websocket_request, api_method, *args, **kwargs):
         api_client.request = prev_request
 
 
-stream = functools.partial(_websocket_reqeust, ws_client.websocket_call)
+stream = functools.partial(_websocket_reqeust, ws_client.websocket_call, None)
+portforward = functools.partial(_websocket_reqeust, ws_client.portforward_call, {'_preload_content':False})

--- a/stream/stream.py
+++ b/stream/stream.py
@@ -16,7 +16,8 @@ from . import ws_client
 
 
 def stream(func, *args, **kwargs):
-    """Stream given API call using websocket"""
+    """Stream given API call using websocket.
+    Extra kwarg: capture-all=True - captures all stdout+stderr for use with WSClient.read_all()"""
 
     def _intercept_request_call(*args, **kwargs):
         # old generated code's api client has config. new ones has

--- a/stream/stream.py
+++ b/stream/stream.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/stream/stream.py
+++ b/stream/stream.py
@@ -17,7 +17,7 @@ import functools
 from . import ws_client
 
 
-def _websocket_reqeust(websocket_request, force_kwargs, api_method, *args, **kwargs):
+def _websocket_request(websocket_request, force_kwargs, api_method, *args, **kwargs):
     """Override the ApiClient.request method with an alternative websocket based
     method and call the supplied Kubernetes API method with that in place."""
     if force_kwargs:
@@ -37,5 +37,5 @@ def _websocket_reqeust(websocket_request, force_kwargs, api_method, *args, **kwa
         api_client.request = prev_request
 
 
-stream = functools.partial(_websocket_reqeust, ws_client.websocket_call, None)
-portforward = functools.partial(_websocket_reqeust, ws_client.portforward_call, {'_preload_content':False})
+stream = functools.partial(_websocket_request, ws_client.websocket_call, None)
+portforward = functools.partial(_websocket_request, ws_client.portforward_call, {'_preload_content':False})

--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -76,7 +76,11 @@ class WSClient:
             ssl_opts['keyfile'] = configuration.key_file
 
         self.sock = WebSocket(sslopt=ssl_opts, skip_utf8_validation=False)
-        self.sock.connect(url, header=header)
+        if configuration.proxy:
+            proxy_url = urlparse(configuration.proxy)
+            self.sock.connect(url, header=header, http_proxy_host=proxy_url.hostname, http_proxy_port=proxy_url.port)
+        else:
+            self.sock.connect(url, header=header)
         self._connected = True
 
     def peek_channel(self, channel, timeout=0):

--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -23,7 +23,7 @@ import time
 import six
 import yaml
 
-from six.moves.urllib.parse import urlencode, quote_plus, urlparse, urlunparse
+from six.moves.urllib.parse import urlencode, urlparse, urlunparse
 from six import StringIO
 
 from websocket import WebSocket, ABNF, enableTrace
@@ -51,47 +51,13 @@ class WSClient:
         like port forwarding can forward different pods' streams to different
         channels.
         """
-        enableTrace(False)
-        header = []
         self._connected = False
         self._channels = {}
         if capture_all:
             self._all = StringIO()
         else:
             self._all = _IgnoredIO()
-
-        # We just need to pass the Authorization, ignore all the other
-        # http headers we get from the generated code
-        if headers and 'authorization' in headers:
-            header.append("authorization: %s" % headers['authorization'])
-
-        if headers and 'sec-websocket-protocol' in headers:
-            header.append("sec-websocket-protocol: %s" %
-                          headers['sec-websocket-protocol'])
-        else:
-            header.append("sec-websocket-protocol: v4.channel.k8s.io")
-
-        if url.startswith('wss://') and configuration.verify_ssl:
-            ssl_opts = {
-                'cert_reqs': ssl.CERT_REQUIRED,
-                'ca_certs': configuration.ssl_ca_cert or certifi.where(),
-            }
-            if configuration.assert_hostname is not None:
-                ssl_opts['check_hostname'] = configuration.assert_hostname
-        else:
-            ssl_opts = {'cert_reqs': ssl.CERT_NONE}
-
-        if configuration.cert_file:
-            ssl_opts['certfile'] = configuration.cert_file
-        if configuration.key_file:
-            ssl_opts['keyfile'] = configuration.key_file
-
-        self.sock = WebSocket(sslopt=ssl_opts, skip_utf8_validation=False)
-        if configuration.proxy:
-            proxy_url = urlparse(configuration.proxy)
-            self.sock.connect(url, header=header, http_proxy_host=proxy_url.hostname, http_proxy_port=proxy_url.port)
-        else:
-            self.sock.connect(url, header=header)
+        self.sock = create_websocket(configuration, url, headers)
         self._connected = True
 
     def peek_channel(self, channel, timeout=0):
@@ -259,41 +225,77 @@ class WSClient:
 WSResponse = collections.namedtuple('WSResponse', ['data'])
 
 
-def get_websocket_url(url):
+def get_websocket_url(url, query_params=None):
     parsed_url = urlparse(url)
     parts = list(parsed_url)
     if parsed_url.scheme == 'http':
         parts[0] = 'ws'
     elif parsed_url.scheme == 'https':
         parts[0] = 'wss'
+    if query_params:
+        query = []
+        for key, value in query_params:
+            if key == 'command' and isinstance(value, list):
+                for command in value:
+                    query.append((key, command))
+            else:
+                query.append((key, value))
+        if query:
+            parts[4] = urlencode(query)
     return urlunparse(parts)
 
 
-def websocket_call(configuration, *args, **kwargs):
+def create_websocket(configuration, url, headers=None):
+    enableTrace(False)
+
+    # We just need to pass the Authorization, ignore all the other
+    # http headers we get from the generated code
+    header = []
+    if headers and 'authorization' in headers:
+            header.append("authorization: %s" % headers['authorization'])
+    if headers and 'sec-websocket-protocol' in headers:
+        header.append("sec-websocket-protocol: %s" %
+                      headers['sec-websocket-protocol'])
+    else:
+        header.append("sec-websocket-protocol: v4.channel.k8s.io")
+
+    if url.startswith('wss://') and configuration.verify_ssl:
+        ssl_opts = {
+            'cert_reqs': ssl.CERT_REQUIRED,
+            'ca_certs': configuration.ssl_ca_cert or certifi.where(),
+        }
+        if configuration.assert_hostname is not None:
+            ssl_opts['check_hostname'] = configuration.assert_hostname
+    else:
+        ssl_opts = {'cert_reqs': ssl.CERT_NONE}
+
+    if configuration.cert_file:
+        ssl_opts['certfile'] = configuration.cert_file
+    if configuration.key_file:
+        ssl_opts['keyfile'] = configuration.key_file
+
+    websocket = WebSocket(sslopt=ssl_opts, skip_utf8_validation=False)
+    if configuration.proxy:
+        proxy_url = urlparse(configuration.proxy)
+        websocket.connect(url, header=header, http_proxy_host=proxy_url.hostname, http_proxy_port=proxy_url.port)
+    else:
+        websocket.connect(url, header=header)
+    return websocket
+
+
+def websocket_call(configuration, _method, url, **kwargs):
     """An internal function to be called in api-client when a websocket
-    connection is required. args and kwargs are the parameters of
+    connection is required. method, url, and kwargs are the parameters of
     apiClient.request method."""
 
-    url = args[1]
+    url = get_websocket_url(url, kwargs.get("query_params"))
+    headers = kwargs.get("headers")
     _request_timeout = kwargs.get("_request_timeout", 60)
     _preload_content = kwargs.get("_preload_content", True)
     capture_all = kwargs.get("capture_all", True)
-    headers = kwargs.get("headers")
-
-    # Expand command parameter list to indivitual command params
-    query_params = []
-    for key, value in kwargs.get("query_params", {}):
-        if key == 'command' and isinstance(value, list):
-            for command in value:
-                query_params.append((key, command))
-        else:
-            query_params.append((key, value))
-
-    if query_params:
-        url += '?' + urlencode(query_params)
 
     try:
-        client = WSClient(configuration, get_websocket_url(url), headers, capture_all)
+        client = WSClient(configuration, url, headers, capture_all)
         if not _preload_content:
             return client
         client.run_forever(timeout=_request_timeout)

--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -133,7 +133,16 @@ class WSClient:
 
     def write_channel(self, channel, data):
         """Write data to a channel."""
-        self.sock.send(chr(channel) + data)
+        # check if we're writing binary data or not
+        binary = six.PY3 and type(data) == six.binary_type
+        opcode = ABNF.OPCODE_BINARY if binary else ABNF.OPCODE_TEXT
+
+        channel_prefix = chr(channel)
+        if binary:
+            channel_prefix = six.binary_type(channel_prefix, "ascii")
+
+        payload = channel_prefix + data
+        self.sock.send(payload, opcode=opcode)
 
     def peek_stdout(self, timeout=0):
         """Same as peek_channel with channel=1."""

--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -181,7 +181,7 @@ class WSClient:
             elif op_code == ABNF.OPCODE_BINARY or op_code == ABNF.OPCODE_TEXT:
                 data = frame.data
                 if six.PY3:
-                    data = data.decode("utf-8")
+                    data = data.decode("utf-8", "replace")
                 if len(data) > 1:
                     channel = ord(data[0])
                     data = data[1:]

--- a/stream/ws_client_test.py
+++ b/stream/ws_client_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,6 @@ envlist = py27, py35, py36, py37
 passenv = TOXENV CI TRAVIS TRAVIS_*
 commands =
    python -V
-   pip install nose
-   ./run_tox.sh nosetests []
+   pip install pytest
+   ./run_tox.sh pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
 envlist =
-   py27, py3{5,6,7,8,9}
-   py27-functional, py3{5,6,7,8,9}-functional
+   py3{5,6,7,8,9}
+   py3{5,6,7,8,9}-functional
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py35, py36, py37
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py27, py35, py36, py37
+envlist =
+   py27, py3{5,6,7,8,9}
+   py27-functional, py3{5,6,7,8,9}-functional
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*

--- a/watch/__init__.py
+++ b/watch/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/watch/watch.py
+++ b/watch/watch.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import http
 import json
 import pydoc
 
@@ -86,7 +87,7 @@ class Watch(object):
     def unmarshal_event(self, data, return_type):
         js = json.loads(data)
         js['raw_object'] = js['object']
-        if return_type:
+        if return_type and js['type'] != 'ERROR':
             obj = SimpleNamespace(data=json.dumps(js['raw_object']))
             js['object'] = self._api_client.deserialize(obj, return_type)
             if hasattr(js['object'], 'metadata'):
@@ -101,6 +102,14 @@ class Watch(object):
 
     def stream(self, func, *args, **kwargs):
         """Watch an API resource and stream the result back via a generator.
+
+        Note that watching an API resource can expire. The method tries to
+        resume automatically once from the last result, but if that last result
+        is too old as well, an `ApiException` exception will be thrown with
+        ``code`` 410. In that case you have to recover yourself, probably
+        by listing the API resource to obtain the latest state and then
+        watching from that state on by setting ``resource_version`` to
+        one returned from listing.
 
         :param func: The API function pointer. Any parameter to the function
                      can be passed after this parameter.
@@ -134,6 +143,7 @@ class Watch(object):
             self.resource_version = kwargs['resource_version']
 
         timeouts = ('timeout_seconds' in kwargs)
+        retry_after_410 = False
         while True:
             resp = func(*args, **kwargs)
             try:
@@ -141,7 +151,23 @@ class Watch(object):
                     # unmarshal when we are receiving events from watch,
                     # return raw string when we are streaming log
                     if watch_arg == "watch":
-                        yield self.unmarshal_event(line, return_type)
+                        event = self.unmarshal_event(line, return_type)
+                        if isinstance(event, dict) \
+                                and event['type'] == 'ERROR':
+                            obj = event['raw_object']
+                            # Current request expired, let's retry,
+                            # but only if we have not already retried.
+                            if not retry_after_410 and \
+                                    obj['code'] == http.HTTPStatus.GONE:
+                                retry_after_410 = True
+                                break
+                            else:
+                                reason = "%s: %s" % (obj['reason'], obj['message'])
+                                raise client.rest.ApiException(status=obj['code'],
+                                                               reason=reason)
+                        else:
+                            retry_after_410 = False
+                            yield event
                     else:
                         yield line
                     if self._stop:

--- a/watch/watch.py
+++ b/watch/watch.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import http
 import json
 import pydoc
+import sys
 
 from kubernetes import client
 
@@ -27,6 +27,15 @@ PYDOC_FOLLOW_PARAM = ":param bool follow:"
 # of type "Namespace". In case this assumption is not true, user should
 # provide return_type to Watch class's __init__.
 TYPE_LIST_SUFFIX = "List"
+
+
+PY2 = sys.version_info[0] == 2
+if PY2:
+    import httplib
+    HTTP_STATUS_GONE = httplib.GONE
+else:
+    import http
+    HTTP_STATUS_GONE = http.HTTPStatus.GONE
 
 
 class SimpleNamespace:
@@ -158,13 +167,14 @@ class Watch(object):
                             # Current request expired, let's retry,
                             # but only if we have not already retried.
                             if not retry_after_410 and \
-                                    obj['code'] == http.HTTPStatus.GONE:
+                                    obj['code'] == HTTP_STATUS_GONE:
                                 retry_after_410 = True
                                 break
                             else:
-                                reason = "%s: %s" % (obj['reason'], obj['message'])
-                                raise client.rest.ApiException(status=obj['code'],
-                                                               reason=reason)
+                                reason = "%s: %s" % (
+                                    obj['reason'], obj['message'])
+                                raise client.rest.ApiException(
+                                    status=obj['code'], reason=reason)
                         else:
                             retry_after_410 = False
                             yield event

--- a/watch/watch.py
+++ b/watch/watch.py
@@ -88,6 +88,8 @@ class Watch(object):
             js = json.loads(data)
         except ValueError:
             return data
+        if not (isinstance(js, dict) and 'object' in js):
+            return data
         js['raw_object'] = js['object']
         if return_type:
             obj = SimpleNamespace(data=json.dumps(js['raw_object']))

--- a/watch/watch.py
+++ b/watch/watch.py
@@ -53,7 +53,7 @@ def _find_return_type(func):
 
 def iter_resp_lines(resp):
     prev = ""
-    for seg in resp.read_chunked(decode_content=False):
+    for seg in resp.stream(amt=None, decode_content=False):
         if isinstance(seg, bytes):
             seg = seg.decode('utf8')
         seg = prev + seg

--- a/watch/watch.py
+++ b/watch/watch.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/watch/watch.py
+++ b/watch/watch.py
@@ -151,7 +151,9 @@ class Watch(object):
         if 'resource_version' in kwargs:
             self.resource_version = kwargs['resource_version']
 
-        timeouts = ('timeout_seconds' in kwargs)
+        # Do not attempt retries if user specifies a timeout.
+        # We want to ensure we are returning within that timeout.
+        disable_retries = ('timeout_seconds' in kwargs)
         retry_after_410 = False
         while True:
             resp = func(*args, **kwargs)
@@ -164,9 +166,9 @@ class Watch(object):
                         if isinstance(event, dict) \
                                 and event['type'] == 'ERROR':
                             obj = event['raw_object']
-                            # Current request expired, let's retry,
+                            # Current request expired, let's retry, (if enabled)
                             # but only if we have not already retried.
-                            if not retry_after_410 and \
+                            if not disable_retries and not retry_after_410 and \
                                     obj['code'] == HTTP_STATUS_GONE:
                                 retry_after_410 = True
                                 break
@@ -190,5 +192,5 @@ class Watch(object):
                 else:
                     self._stop = True
 
-            if timeouts or self._stop:
+            if self._stop or disable_retries:
                 break

--- a/watch/watch.py
+++ b/watch/watch.py
@@ -84,12 +84,7 @@ class Watch(object):
             return 'watch'
 
     def unmarshal_event(self, data, return_type):
-        try:
-            js = json.loads(data)
-        except ValueError:
-            return data
-        if not (isinstance(js, dict) and 'object' in js):
-            return data
+        js = json.loads(data)
         js['raw_object'] = js['object']
         if return_type:
             obj = SimpleNamespace(data=json.dumps(js['raw_object']))
@@ -132,7 +127,8 @@ class Watch(object):
 
         self._stop = False
         return_type = self.get_return_type(func)
-        kwargs[self.get_watch_argument_name(func)] = True
+        watch_arg = self.get_watch_argument_name(func)
+        kwargs[watch_arg] = True
         kwargs['_preload_content'] = False
         if 'resource_version' in kwargs:
             self.resource_version = kwargs['resource_version']
@@ -142,7 +138,12 @@ class Watch(object):
             resp = func(*args, **kwargs)
             try:
                 for line in iter_resp_lines(resp):
-                    yield self.unmarshal_event(line, return_type)
+                    # unmarshal when we are receiving events from watch,
+                    # return raw string when we are streaming log
+                    if watch_arg == "watch":
+                        yield self.unmarshal_event(line, return_type)
+                    else:
+                        yield line
                     if self._stop:
                         break
             finally:

--- a/watch/watch.py
+++ b/watch/watch.py
@@ -96,7 +96,11 @@ class Watch(object):
     def unmarshal_event(self, data, return_type):
         js = json.loads(data)
         js['raw_object'] = js['object']
-        if return_type and js['type'] != 'ERROR':
+        # BOOKMARK event is treated the same as ERROR for a quick fix of
+        # decoding exception
+        # TODO: make use of the resource_version in BOOKMARK event for more
+        # efficient WATCH
+        if return_type and js['type'] != 'ERROR' and js['type'] != 'BOOKMARK':
             obj = SimpleNamespace(data=json.dumps(js['raw_object']))
             js['object'] = self._api_client.deserialize(obj, return_type)
             if hasattr(js['object'], 'metadata'):

--- a/watch/watch_test.py
+++ b/watch/watch_test.py
@@ -255,6 +255,19 @@ class WatchTests(unittest.TestCase):
         self.assertEqual("1", event['object']['metadata']['resourceVersion'])
         self.assertEqual("1", w.resource_version)
 
+    def test_unmarshal_with_bookmark(self):
+        w = Watch()
+        event = w.unmarshal_event(
+            '{"type":"BOOKMARK","object":{"kind":"Job","apiVersion":"batch/v1"'
+            ',"metadata":{"resourceVersion":"1"},"spec":{"template":{'
+            '"metadata":{},"spec":{"containers":null}}},"status":{}}}',
+            'V1Job')
+        self.assertEqual("BOOKMARK", event['type'])
+        # Watch.resource_version is *not* updated, as BOOKMARK is treated the
+        # same as ERROR for a quick fix of decoding exception,
+        # resource_version in BOOKMARK is *not* used at all.
+        self.assertEqual(None, w.resource_version)
+
     def test_watch_with_exception(self):
         fake_resp = Mock()
         fake_resp.close = Mock()

--- a/watch/watch_test.py
+++ b/watch/watch_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2016 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

According to fabianvf's suggestion, I try to catch the exception in the first call and safely ignore it

https://github.com/kubernetes-client/python/issues/1536#issuecomment-920265516

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-client/python/issues/1536

#### Does this PR introduce a user-facing change?

```release-note
Ignore NotFoundError in the first call of LazyDiscoverer. __search
```