### PR TITLE
fix: ignore NotFoundError in the first call of LazyDiscoverer. __search

### DIFF
--- a/dynamic/discovery.py
+++ b/dynamic/discovery.py
@@ -237,7 +237,11 @@ class LazyDiscoverer(Discoverer):
         return self.parse_api_groups(request_resources=False, update=True)['apis'].keys()
 
     def search(self, **kwargs):
-        results = self.__search(self.__build_search(**kwargs), self.__resources, [])
+        # In first call, ignore ResourceNotFoundError and set default value for results
+        try:
+            results = self.__search(self.__build_search(**kwargs), self.__resources, [])
+        except ResourceNotFoundError:
+            results = []
         if not results:
             self.invalidate_cache()
             results = self.__search(self.__build_search(**kwargs), self.__resources, [])


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

According to fabianvf's suggestion, I try to catch the exception in the first call and safely ignore it

https://github.com/kubernetes-client/python/issues/1536#issuecomment-920265516

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-client/python/issues/1536

#### Does this PR introduce a user-facing change?

```release-note
Ignore NotFoundError in the first call of LazyDiscoverer. __search
```