### PR TITLE
add proxy authentication supporting for websocket (stream/ws_client.py)

### DIFF
--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -29,6 +29,7 @@ from six.moves.urllib.parse import urlencode, urlparse, urlunparse
 from six import StringIO
 
 from websocket import WebSocket, ABNF, enableTrace
+from base64 import b64decode
 
 STDIN_CHANNEL = 0
 STDOUT_CHANNEL = 1
@@ -445,11 +446,20 @@ def create_websocket(configuration, url, headers=None):
         ssl_opts['keyfile'] = configuration.key_file
 
     websocket = WebSocket(sslopt=ssl_opts, skip_utf8_validation=False)
+    connect_opt = {
+         'header': header
+    }
     if configuration.proxy:
         proxy_url = urlparse(configuration.proxy)
-        websocket.connect(url, header=header, http_proxy_host=proxy_url.hostname, http_proxy_port=proxy_url.port)
-    else:
-        websocket.connect(url, header=header)
+        connect_opt.update({'http_proxy_host': proxy_url.hostname, 'http_proxy_port': proxy_url.port})
+    if configuration.proxy_headers:
+       for key,value in configuration.proxy_headers.items():
+          if key == 'proxy-authorization' and value.startswith('Basic'):
+             b64value = value.split()[1]
+             auth = b64decode(b64value).decode().split(':')
+             connect_opt.update({'http_proxy_auth': (auth[0], auth[1]) })
+
+    websocket.connect(url, **connect_opt)
     return websocket
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR supports proxy authentication for websocket client.
as described in #255, and https://github.com/ansible-collections/kubernetes.core/issues/246
current kubernets-client/python(-base) support proxy auth only for REST but NOT websocket.
as the result, kubernets.core's k8s_cp nor k8s_exec cannot work with proxy when proxy requires authentication.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #255
Fixes https://github.com/ansible-collections/kubernetes.core/issues/246


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
