### PR TITLE
Make socket Windows-proof

### DIFF
--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -280,7 +280,7 @@ class PortForward:
             # between the python application and the kubernetes websocket. The self.python
             # half of the socket pair is used by the _proxy method to receive and send data
             # to the running python application.
-            s, self.python = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
+            s, self.python = socket.socketpair()
             # The self.socket half of the pair is used by the python application to send
             # and receive data to the eventual pod port. It is wrapped in the _Socket class
             # because a socket pair is an AF_UNIX socket, not a AF_INET socket. This allows


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
Opening a socket on a portforward with the python kubernetes client on Windows fails with the exception: `module 'socket' has no attribute 'AF_UNIX'`. See [https://github.com/kubernetes-client/python/issues/1558](https://github.com/kubernetes-client/python/issues/1558)

#### Which issue(s) this PR fixes:
Fixes #1558

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
