### PR TITLE
[config] Add a new method of config.kube_config.new_client_from_config_dict

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -18,7 +18,7 @@ from .config_exception import ConfigException
 from .incluster_config import load_incluster_config
 from .kube_config import (KUBE_CONFIG_DEFAULT_LOCATION,
                           list_kube_config_contexts, load_kube_config,
-                          load_kube_config_from_dict, new_client_from_config)
+                          load_kube_config_from_dict, new_client_from_config, new_client_from_config_dict)
 
 
 def load_config(**kwargs):

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -871,3 +871,21 @@ def new_client_from_config(
                      client_configuration=client_config,
                      persist_config=persist_config)
     return ApiClient(configuration=client_config)
+
+
+def new_client_from_config_dict(
+        config_dict=None,
+        context=None,
+        persist_config=True,
+        temp_file_path=None):
+    """
+    Loads configuration the same as load_kube_config_from_dict but returns an ApiClient
+    to be used with any API object. This will allow the caller to concurrently
+    talk with multiple clusters.
+    """
+    client_config = type.__call__(Configuration)
+    load_kube_config_from_dict(config_dict=config_dict, context=context,
+                               client_configuration=client_config,
+                               persist_config=persist_config,
+                               temp_file_path=temp_file_path)
+    return ApiClient(configuration=client_config)

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -37,7 +37,7 @@ from .kube_config import (ENV_KUBECONFIG_PATH_SEPARATOR, CommandTokenSource,
                           _get_kube_config_loader,
                           _get_kube_config_loader_for_yaml_file,
                           list_kube_config_contexts, load_kube_config,
-                          load_kube_config_from_dict, new_client_from_config)
+                          load_kube_config_from_dict, new_client_from_config, new_client_from_config_dict)
 
 BEARER_TOKEN_FORMAT = "Bearer %s"
 
@@ -1347,6 +1347,13 @@ class TestKubeConfigLoader(BaseTestCase):
             yaml.safe_dump(self.TEST_KUBE_CONFIG))
         client = new_client_from_config(
             config_file=config_file, context="simple_token")
+        self.assertEqual(TEST_HOST, client.configuration.host)
+        self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
+                         client.configuration.api_key['authorization'])
+
+    def test_new_client_from_config_dict(self):
+        client = new_client_from_config_dict(
+            config_dict=self.TEST_KUBE_CONFIG, context="simple_token")
         self.assertEqual(TEST_HOST, client.configuration.host)
         self.assertEqual(BEARER_TOKEN_FORMAT % TEST_DATA_BASE64,
                          client.configuration.api_key['authorization'])


### PR DESCRIPTION
Signed-off-by: WalkerWang731 <wxy1990731@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
It same as `load_kube_config_from_dict` but returns an ApiClient to be used with any API object. This will allow the caller to concurrently talk with multiple clusters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #265 

#### Special notes for your reviewer:
unittest result:
```
$ python -m unittest config.kube_config_test.TestKubeConfigLoader.test_new_client_from_config_dict
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
from kubernetes.config import kube_config

api_client=kube_config.new_client_from_config_dict(config_dict=CONFIG_DICT))
```
## Background
Add a new method that user can get an `ApiClient` object directly.

it same as `load_kube_config_from_dict` but returns an ApiClient to be used with any API object. This will allow the caller to concurrently talk with multiple clusters.

## How to use

```
from kubernetes.config import kube_config

api_client=kube_config.new_client_from_config_dict(config_dict=CONFIG_DICT))
```

