### PR TITLE
Fix leaderelection/example.py, now works in package.

### DIFF
--- a/leaderelection/example.py
+++ b/leaderelection/example.py
@@ -14,9 +14,9 @@
 
 import uuid
 from kubernetes import client, config
-from leaderelection import leaderelection
-from leaderelection.resourcelock.configmaplock import ConfigMapLock
-from leaderelection import electionconfig
+from kubernetes.leaderelection import leaderelection
+from kubernetes.leaderelection.resourcelock.configmaplock import ConfigMapLock
+from kubernetes.leaderelection import electionconfig
 
 
 # Authenticate using config file

--- a/leaderelection/resourcelock/configmaplock.py
+++ b/leaderelection/resourcelock/configmaplock.py
@@ -15,7 +15,7 @@
 from kubernetes.client.rest import ApiException
 from kubernetes import client, config
 from kubernetes.client.api_client import ApiClient
-from leaderelection.leaderelectionrecord import LeaderElectionRecord
+from ..leaderelectionrecord import LeaderElectionRecord
 import json
 import logging
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes the leader election so the example.py under leaderelection can work (almost) out-of-box. Including a fix of absolute import on `leaderelection`.

#### Which issue(s) this PR fixes:

Related to issue https://github.com/kubernetes-client/python/issues/1475 and PR https://github.com/kubernetes-client/python/pull/1631

#### Special notes for your reviewer:

It'd be great if this can be merged before https://github.com/kubernetes-client/python/pull/1631.

I'm not sure if its best to move the example.py and README.py under leaderelection to the kubernetes project's example folder, happy to proceed this way if this is something we are interested.

#### Does this PR introduce a user-facing change?

No.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None.