### PR TITLE
make use of logger in config init file

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -21,7 +21,6 @@ from .kube_config import (KUBE_CONFIG_DEFAULT_LOCATION,
                           list_kube_config_contexts, load_kube_config,
                           load_kube_config_from_dict, new_client_from_config, new_client_from_config_dict)
 
-logging.basicConfig(level=logging.INFO)
 
 def load_config(**kwargs):
     """

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 
 from os.path import exists, expanduser
 
@@ -20,6 +21,7 @@ from .kube_config import (KUBE_CONFIG_DEFAULT_LOCATION,
                           list_kube_config_contexts, load_kube_config,
                           load_kube_config_from_dict, new_client_from_config, new_client_from_config_dict)
 
+logging.basicConfig(level=logging.INFO)
 
 def load_config(**kwargs):
     """
@@ -36,7 +38,7 @@ def load_config(**kwargs):
     if "kube_config_path" in kwargs.keys() or exists(expanduser(KUBE_CONFIG_DEFAULT_LOCATION)):
         load_kube_config(**kwargs)
     else:
-        print(
+        logging.warning(
             "kube_config_path not provided and "
             "default location ({0}) does not exist. "
             "Using inCluster Config. "


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
This PR makes use of logging instead of standard printing out the output

<!--
Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In config/__init__.py instead of giving the output in stdout python logger is used to display a warning when kube config path is not provided 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #263 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
