### PR TITLE
Run kubeconfig exec commands in the correct directory

### DIFF
--- a/config/exec_provider.py
+++ b/config/exec_provider.py
@@ -31,7 +31,7 @@ class ExecProvider(object):
     * caching
     """
 
-    def __init__(self, exec_config):
+    def __init__(self, exec_config, cwd):
         """
         exec_config must be of type ConfigNode because we depend on
         safe_get(self, key) to correctly handle optional exec provider
@@ -53,6 +53,7 @@ class ExecProvider(object):
                 value = item['value']
                 additional_vars[name] = value
             self.env.update(additional_vars)
+        self.cwd = cwd
 
     def run(self, previous_response=None):
         kubernetes_exec_info = {
@@ -69,6 +70,7 @@ class ExecProvider(object):
             self.args,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            cwd=self.cwd,
             env=self.env,
             universal_newlines=True)
         (stdout, stderr) = process.communicate()

--- a/config/kube_config.py
+++ b/config/kube_config.py
@@ -483,7 +483,8 @@ class KubeConfigLoader(object):
         if 'exec' not in self._user:
             return
         try:
-            status = ExecProvider(self._user['exec']).run()
+            base_path = self._get_base_path(self._cluster.path)
+            status = ExecProvider(self._user['exec'], base_path).run()
             if 'token' in status:
                 self.token = "Bearer %s" % status['token']
             elif 'clientCertificateData' in status:
@@ -493,7 +494,6 @@ class KubeConfigLoader(object):
                     logging.error('exec: missing clientKeyData field in '
                                   'plugin output')
                     return None
-                base_path = self._get_base_path(self._cluster.path)
                 self.cert_file = FileOrData(
                     status, None,
                     data_key_name='clientCertificateData',

--- a/config/kube_config_test.py
+++ b/config/kube_config_test.py
@@ -1441,6 +1441,20 @@ class TestKubeConfigLoader(BaseTestCase):
             active_context="exec_cred_user_certificate").load_and_set(actual)
         self.assertEqual(expected, actual)
 
+    @mock.patch('kubernetes.config.kube_config.ExecProvider.run', autospec=True)
+    def test_user_exec_cwd(self, mock):
+        capture = {}
+        def capture_cwd(exec_provider):
+            capture['cwd'] = exec_provider.cwd
+        mock.side_effect = capture_cwd
+
+        expected = "/some/random/path"
+        KubeConfigLoader(
+            config_dict=self.TEST_KUBE_CONFIG,
+            active_context="exec_cred_user",
+            config_base_path=expected).load_and_set(FakeConfig())
+        self.assertEqual(expected, capture['cwd'])
+
     def test_user_cmd_path(self):
         A = namedtuple('A', ['token', 'expiry'])
         token = "dummy"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Kubeconfigs with exec specifications should invoke them so that referenced relative paths are relative to the config itself: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#file-references . The current implementation in this library does not do so, so this PR fixes it.

I am not sure how to fix the config/kube_config_test.py tests because they patch `kubernetes.config.kube_config.ExecProvider` rather than the `ExecProvider` implementation in this PR, and for a similar reason I suspect the current `from kubernetes.config.exec_provider import ExecProvider` in `config/kube_config.py` will cause problems. But once this submodule is updated I think this should work fine, so not sure if there's anything I need to do.

#### Which issue(s) this PR fixes:

I didn't find a filed bug about this.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```