### PR TITLE
fix leaderelection:  release lock when error occour and graceful shot…

### DIFF
--- a/leaderelection/electionconfig.py
+++ b/leaderelection/electionconfig.py
@@ -19,7 +19,7 @@ logging.basicConfig(level=logging.INFO)
 
 class Config:
     # Validate config, exit if an error is detected
-    def __init__(self, lock, lease_duration, renew_deadline, retry_period, onstarted_leading, onstopped_leading):
+    def __init__(self, lock, lease_duration, renew_deadline, retry_period, onstarted_leading, onstopped_leading, release_on_cancel=False):
         self.jitter_factor = 1.2
 
         if lock is None:
@@ -44,6 +44,7 @@ class Config:
         self.lease_duration = lease_duration
         self.renew_deadline = renew_deadline
         self.retry_period = retry_period
+        self.release_on_cancel = release_on_cancel
 
         if onstarted_leading is None:
             sys.exit("callback onstarted_leading cannot be None")

--- a/leaderelection/example.py
+++ b/leaderelection/example.py
@@ -45,7 +45,7 @@ def example_func():
 # Create config
 config = electionconfig.Config(ConfigMapLock(lock_name, lock_namespace, candidate_id), lease_duration=17,
                                renew_deadline=15, retry_period=5, onstarted_leading=example_func,
-                               onstopped_leading=None)
+                               onstopped_leading=None, release_on_cancel=True)
 
 # Enter leader election
 leaderelection.LeaderElection(config).run()

--- a/leaderelection/leaderelection.py
+++ b/leaderelection/leaderelection.py
@@ -58,13 +58,17 @@ class LeaderElection:
             logging.info("{} successfully acquired lease".format(self.election_config.lock.identity))
 
             # Start leading and call OnStartedLeading()
-            threading.daemon = True
-            threading.Thread(target=self.election_config.onstarted_leading).start()
+            try:
+                threading.daemon = True
+                threading.Thread(target=self.election_config.onstarted_leading).start()
 
-            self.renew_loop()
+                self.renew_loop()
+            finally:
+                if self.election_config.release_on_cancel:
+                    self.release()
+                # Failed to update lease, run OnStoppedLeading callback
+                self.election_config.onstopped_leading()
 
-            # Failed to update lease, run OnStoppedLeading callback
-            self.election_config.onstopped_leading()
 
     def acquire(self):
         # Follower
@@ -103,6 +107,15 @@ class LeaderElection:
 
             # failed to renew, return
             return
+    
+    def release(self):
+        lock_status, old_election_record = self.election_config.lock.get(self.election_config.lock.name,
+                                                                        self.election_config.lock.namespace)
+        if lock_status:
+            logging.info("release lock: {}".format(old_election_record.holder_identity))
+            old_election_record.lease_duration = 1
+            old_election_record.holder_identity = None
+            self.update_lock(old_election_record)
 
     def try_acquire_or_renew(self):
         now_timestamp = time.time()
@@ -187,5 +200,6 @@ class LeaderElection:
 
         self.observed_record = leader_election_record
         self.observed_time_milliseconds = int(time.time() * 1000)
-        logging.info("leader {} has successfully acquired lease".format(leader_election_record.holder_identity))
+        if leader_election_record.holder_identity:
+            logging.info("leader {} has successfully acquired lease".format(leader_election_record.holder_identity))
         return True


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
release lock when error occour and graceful shotdown

#### Which issue(s) this PR fixes:
Fixes #278

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
