### PR TITLE
Fix WSClient.update() exception when eventlet has monkey_patched select

### DIFF
--- a/stream/ws_client.py
+++ b/stream/ws_client.py
@@ -177,9 +177,11 @@ class WSClient:
         #                   implementation.
         # select.poll()   - this will work on most unix based OS, but not as
         #                   efficient as epoll. Will work for fd numbers above 1024.
+        #                   Will not work on Linux when eventlet is being used.
         # select.epoll()  - newest and most efficient way of polling.
         #                   However, only works on linux.
-        if sys.platform.startswith('linux') or sys.platform in ['darwin']:
+        if ((sys.platform.startswith('linux') and getattr(select, "poll", None) is not None) or
+                sys.platform in ['darwin']):
             poll = select.poll()
             poll.register(self.sock.sock, select.POLLIN)
             r = poll.poll(timeout)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
Fixes exception in WSClient.update() caused by select not having a poll() attribute when running under eventlet.  Introduced by PR #268 

#### Which issue(s) this PR fixes:
Fixes #281 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
